### PR TITLE
Fixed unable to find etc/download.json

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include ir_datasets/docs/*.yaml
-include ir_datasets/etc/*.yaml
+include ir_datasets/etc/*.json
 include requirements.txt
 include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
         'console_scripts': ['ir_datasets=ir_datasets:main_cli'],
     },
     package_data={
-        'ir_datasets': glob('docs/*.yaml') + glob('etc/*.yaml'),
+        'ir_datasets': glob('docs/*.yaml') + glob('etc/*.json'),
         '': ['requirements.txt', 'LICENSE'],
     },
 )


### PR DESCRIPTION
Building and using ir_datasets from source will result in an FileNotFoundError: ..../etc/download.json
Fixed this error by updating MANIFEST.in and setup.py