### PR TITLE
corpus_id function

### DIFF
--- a/ir_datasets/__init__.py
+++ b/ir_datasets/__init__.py
@@ -15,6 +15,33 @@ def load(name):
     return registry[name]
 
 
+def corpus_id(dataset_id: str) -> str:
+    """
+    Maps a dataset_id to a more general ID that shares the same corpus (i.e., docs_handler). For example,
+    "msmarco-document/trec-dl-2019/judged" -> "msmarco-document" or "wikir/en1k/test" -> "wikir/en1k".
+    This is useful when creating shared document resources among multiple subsets, such as
+    an index.
+
+    Note: At this time, this function operates by convention; it finds the lowest dataset_id in the
+    hierarchy that has the same docs_handler instance. This function may be updated in the future to
+    also use explicit links added when datasets are registered.
+    """
+    # adapted from https://github.com/Georgetown-IR-Lab/OpenNIR/blob/master/onir/datasets/irds.py#L47
+    ds = load(dataset_id)
+    segments = dataset_id.split("/")
+    docs_handler = ds.docs_handler()
+    parent_corpus_ds = dataset_id
+    while len(segments) > 1:
+        segments.pop()
+        try:
+            parent_ds = load("/".join(segments))
+            if parent_ds.has_docs() and parent_ds.docs_handler() == docs_handler:
+                parent_corpus_ds = "/".join(segments)
+        except KeyError:
+            pass # this dataset doesn't exist
+    return parent_corpus_ds
+
+
 def create_dataset(docs_tsv=None, queries_tsv=None, qrels_trec=None):
     LocalDownload = util.LocalDownload
     TsvDocs = formats.TsvDocs

--- a/ir_datasets/datasets/clueweb09.py
+++ b/ir_datasets/datasets/clueweb09.py
@@ -179,25 +179,25 @@ def _init():
         documentation('trec-web-2012'))
 
     subsets['catb/trec-web-2009'] = Dataset(
-        collection_en,
+        collection_catb,
         TrecXmlQueries(dlc['trec-web-2009/queries'], qtype=TrecWebTrackQuery, namespace=NAME, lang='en'),
         CatBQrelFilter(TrecPrels(GzipExtract(dlc['trec-web-2009/qrels.adhoc']), QREL_DEFS_09)),
         documentation('trec-web-2009'))
 
     subsets['catb/trec-web-2010'] = Dataset(
-        collection_en,
+        collection_catb,
         TrecXmlQueries(dlc['trec-web-2010/queries'], qtype=TrecWebTrackQuery, namespace=NAME, lang='en'),
         CatBQrelFilter(TrecQrels(dlc['trec-web-2010/qrels.adhoc'], QREL_DEFS)),
         documentation('trec-web-2010'))
 
     subsets['catb/trec-web-2011'] = Dataset(
-        collection_en,
+        collection_catb,
         TrecXmlQueries(dlc['trec-web-2011/queries'], qtype=TrecWebTrackQuery, namespace=NAME, lang='en'),
         CatBQrelFilter(TrecQrels(dlc['trec-web-2011/qrels.adhoc'], QREL_DEFS)),
         documentation('trec-web-2011'))
 
     subsets['catb/trec-web-2012'] = Dataset(
-        collection_en,
+        collection_catb,
         TrecXmlQueries(dlc['trec-web-2012/queries'], qtype=TrecWebTrackQuery, namespace=NAME, lang='en'),
         CatBQrelFilter(TrecQrels(dlc['trec-web-2012/qrels.adhoc'], QREL_DEFS)),
         documentation('trec-web-2012'))

--- a/test/util.py
+++ b/test/util.py
@@ -20,6 +20,21 @@ class TestUtil(unittest.TestCase):
     	self.assertEqual(ass(slice(0, 100), slice(1/3, 2/3)), slice(33, 66))
     	self.assertEqual(ass(slice(0, 100), slice(2/3, 3/3)), slice(66, 100))
 
+    def test_corpus_id(self):
+        # typical
+        self.assertEqual(ir_datasets.corpus_id("msmarco-document/trec-dl-2019/judged"), "msmarco-document")
+        # identity
+        self.assertEqual(ir_datasets.corpus_id("msmarco-document"), "msmarco-document")
+        # wikir doesn't support docs
+        self.assertEqual(ir_datasets.corpus_id("wikir/en1k/test"), "wikir/en1k")
+        # clueweb09 supports docs, but clueweb09/catb is a different subset
+        self.assertEqual(ir_datasets.corpus_id("clueweb09/catb/trec-web-2009"), "clueweb09/catb")
+        self.assertEqual(ir_datasets.corpus_id("clueweb09/catb"), "clueweb09/catb")
+        self.assertEqual(ir_datasets.corpus_id("clueweb09"), "clueweb09")
+        # clirmatrix uses matching patterns
+        self.assertEqual(ir_datasets.corpus_id("clirmatrix/en"), "clirmatrix/en")
+        self.assertEqual(ir_datasets.corpus_id("clirmatrix/en/bi139-full/de/train"), "clirmatrix/en")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added a function to get the "corpus id" based on a dataset ID. I.e., the ID of the "parent" dataset that shares the same docs handler.

For now, this is based on naming conventions and matching docs handlers. But it could be updated in the future to use a more structured version of this information.

This functionality is done already in OpenNIR and Capreolus; this function could replace the code in those places.