### PR TITLE
Add args.me corpus

### DIFF
--- a/.github/workflows/verify_downloads.yml
+++ b/.github/workflows/verify_downloads.yml
@@ -88,6 +88,31 @@ jobs:
         name: "aquaint.json"
         path: "aquaint.json"
 
+  argsme:
+    if: "!github.event.inputs.dataset || github.event.inputs.dataset == 'argsme'"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Test
+      env:
+        IR_DATASETS_DL_DISABLE_PBAR: 'true'
+      run: |
+        python -m test.downloads --filter "^argsme/" --output "argsme.json" --randdelay 60
+    - name: Upload artifact
+      if: always() # don't skip if the Test step fails (defeats the whole purpose)
+      uses: actions/upload-artifact@v2
+      with:
+        name: "argsme.json"
+        path: "argsme.json"
+
   beir:
     if: "!github.event.inputs.dataset || github.event.inputs.dataset == 'beir'"
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -238,3 +238,4 @@ Contributors to this repository:
  - Sean MacAvaney (University of Glasgow)
  - Shuo Sun (Johns Hopkins University)
  - Thomas Jänich (University of Glasgow)
+ - Jan Heinrich Reimer (Martin Luther University Halle-Wittenberg)

--- a/ir_datasets/datasets/__init__.py
+++ b/ir_datasets/datasets/__init__.py
@@ -2,6 +2,7 @@ from . import base
 from . import antique
 from . import aol_ia
 from . import aquaint
+from . import argsme
 from . import beir
 from . import c4
 from . import car

--- a/ir_datasets/datasets/argsme.py
+++ b/ir_datasets/datasets/argsme.py
@@ -1,16 +1,35 @@
+from itertools import chain
+from typing import Dict
+
 from ir_datasets import Dataset, registry
 from ir_datasets.datasets.base import YamlDocumentation
-from ir_datasets.formats.argsme import ArgsMeArguments
+from ir_datasets.formats.argsme import ArgsMeArguments, ArgsMeCombinedArguments
 from ir_datasets.util import DownloadConfig, home_path, Cache, ZipExtract
 
 NAME = "argsme"
 
 SUBSETS = {
+    '1.0': (387692, "en", "args-me.json"),
+    '1.0-cleaned': (382545, "en", "args-me-1.0-cleaned.json"),
     '2020-04-01/debateorg': (338620, "en", "debateorg.json"),
     '2020-04-01/debatepedia': (21197, "en", "debatepedia.json"),
     '2020-04-01/debatewise': (14353, "en", "debatewise.json"),
     '2020-04-01/idebate': (13522, "en", "idebate.json"),
     '2020-04-01/parliamentary': (48, "en", "parliamentary.json"),
+}
+
+COMBINED_SUBSETS = {
+    '2020-04-01': (
+        [
+            '2020-04-01/debateorg',
+            '2020-04-01/debatepedia',
+            '2020-04-01/debatewise',
+            '2020-04-01/idebate',
+            '2020-04-01/parliamentary'
+        ],
+        387740,
+        "en"
+    ),
 }
 
 
@@ -22,30 +41,54 @@ def _init():
 
     base = Dataset(documentation('_'))
 
-    subsets = {
-        name: Dataset(
-            ArgsMeArguments(
-                Cache(
-                    ZipExtract(
-                        download_config[name],
-                        zip_path
-                    ),
-                    base_path / f"{name}.json"
+    # Arguments that can be loaded from Zenodo.
+    arguments: Dict[str, ArgsMeArguments] = {
+        name: ArgsMeArguments(
+            Cache(
+                ZipExtract(
+                    download_config[name],
+                    zip_path
                 ),
-                namespace=f"{NAME}/{name}",
-                language=language,
-                count_hint=count_hint
+                base_path / f"{name}.json"
             ),
-            documentation(name)
+            namespace=f"{NAME}/{name}",
+            language=language,
+            count_hint=count_hint
         )
-        for name, (count_hint, language, zip_path) in SUBSETS.items()
+        for name, (count_hint, language, zip_path)
+        in SUBSETS.items()
     }
 
+    # Arguments that are combined versions of other subsets.
+    combined_arguments: Dict[str, ArgsMeCombinedArguments] = {
+        name: ArgsMeCombinedArguments(
+            [arguments[subset_name] for subset_name in subset_names],
+            namespace=f"{NAME}/{name}",
+            language=language,
+            count_hint=count_hint
+        )
+        for name, (subset_names, count_hint, language)
+        in COMBINED_SUBSETS.items()
+    }
+
+    # Wrap in datasets with documentation.
+    datasets = {
+        name: Dataset(
+            arguments,
+            documentation(name)
+        )
+        for name, arguments in chain(
+            arguments.items(),
+            combined_arguments.items()
+        )
+    }
+
+    # Register datasets.
     registry.register(NAME, base)
-    for name, arguments in subsets.items():
+    for name, arguments in datasets.items():
         registry.register(f'{NAME}/{name}', arguments)
 
-    return base, subsets
+    return base, datasets
 
 
 dataset = _init()

--- a/ir_datasets/datasets/argsme.py
+++ b/ir_datasets/datasets/argsme.py
@@ -6,11 +6,11 @@ from ir_datasets.util import DownloadConfig, home_path, Cache, ZipExtract
 NAME = "argsme"
 
 SUBSETS = {
-    'debateorg': (338620, "en"),
-    'debatepedia': (21197, "en"),
-    'debatewise': (14353, "en"),
-    'idebate': (13522, "en"),
-    'parliamentary': (48, "en"),
+    '2020-04-01/debateorg': (338620, "en"),
+    '2020-04-01/debatepedia': (21197, "en"),
+    '2020-04-01/debatewise': (14353, "en"),
+    '2020-04-01/idebate': (13522, "en"),
+    '2020-04-01/parliamentary': (48, "en"),
 }
 
 

--- a/ir_datasets/datasets/argsme.py
+++ b/ir_datasets/datasets/argsme.py
@@ -1,0 +1,51 @@
+from ir_datasets import Dataset, registry
+from ir_datasets.datasets.base import YamlDocumentation
+from ir_datasets.formats.argsme import ArgsMeArguments
+from ir_datasets.util import DownloadConfig, home_path, Cache, ZipExtract
+
+NAME = "argsme"
+
+SUBSETS = {
+    'debateorg': (338620, "en"),
+    'debatepedia': (21197, "en"),
+    'debatewise': (14353, "en"),
+    'idebate': (13522, "en"),
+    'parliamentary': (48, "en"),
+}
+
+
+def _init():
+    base_path = home_path() / NAME
+
+    documentation = YamlDocumentation(f"docs/{NAME}.yaml")
+    download_config = DownloadConfig.context(NAME, base_path)
+
+    base = Dataset(documentation('_'))
+
+    subsets = {
+        name: Dataset(
+            ArgsMeArguments(
+                Cache(
+                    ZipExtract(
+                        download_config[name],
+                        f"{name}.json"
+                    ),
+                    base_path / f"{name}.json"
+                ),
+                namespace=f"{NAME}/{name}",
+                language=language,
+                count_hint=count_hint
+            ),
+            documentation(name)
+        )
+        for name, (count_hint, language) in SUBSETS.items()
+    }
+
+    registry.register(NAME, base)
+    for name, arguments in subsets.items():
+        registry.register(f'{NAME}/{name}', arguments)
+
+    return base, subsets
+
+
+dataset = _init()

--- a/ir_datasets/datasets/argsme.py
+++ b/ir_datasets/datasets/argsme.py
@@ -3,7 +3,7 @@ from typing import Dict
 
 from ir_datasets import registry
 from ir_datasets.datasets.base import Dataset, YamlDocumentation
-from ir_datasets.formats.argsme import ArgsMeArguments, ArgsMeCombinedArguments
+from ir_datasets.formats.argsme import ArgsMeDocs, ArgsMeCombinedArguments
 from ir_datasets.util import DownloadConfig, home_path, Cache, ZipExtract
 
 NAME = "argsme"
@@ -42,8 +42,8 @@ def _init():
     base = Dataset(documentation('_'))
 
     # Arguments that can be loaded from Zenodo.
-    arguments: Dict[str, ArgsMeArguments] = {
-        name: ArgsMeArguments(
+    arguments: Dict[str, ArgsMeDocs] = {
+        name: ArgsMeDocs(
             Cache(
                 ZipExtract(
                     download_config[name],

--- a/ir_datasets/datasets/argsme.py
+++ b/ir_datasets/datasets/argsme.py
@@ -6,11 +6,11 @@ from ir_datasets.util import DownloadConfig, home_path, Cache, ZipExtract
 NAME = "argsme"
 
 SUBSETS = {
-    '2020-04-01/debateorg': (338620, "en"),
-    '2020-04-01/debatepedia': (21197, "en"),
-    '2020-04-01/debatewise': (14353, "en"),
-    '2020-04-01/idebate': (13522, "en"),
-    '2020-04-01/parliamentary': (48, "en"),
+    '2020-04-01/debateorg': (338620, "en", "debateorg.json"),
+    '2020-04-01/debatepedia': (21197, "en", "debatepedia.json"),
+    '2020-04-01/debatewise': (14353, "en", "debatewise.json"),
+    '2020-04-01/idebate': (13522, "en", "idebate.json"),
+    '2020-04-01/parliamentary': (48, "en", "parliamentary.json"),
 }
 
 
@@ -28,7 +28,7 @@ def _init():
                 Cache(
                     ZipExtract(
                         download_config[name],
-                        f"{name}.json"
+                        zip_path
                     ),
                     base_path / f"{name}.json"
                 ),
@@ -38,7 +38,7 @@ def _init():
             ),
             documentation(name)
         )
-        for name, (count_hint, language) in SUBSETS.items()
+        for name, (count_hint, language, zip_path) in SUBSETS.items()
     }
 
     registry.register(NAME, base)

--- a/ir_datasets/datasets/argsme.py
+++ b/ir_datasets/datasets/argsme.py
@@ -62,6 +62,7 @@ def _init():
     # Arguments that are combined versions of other subsets.
     combined_arguments: Dict[str, ArgsMeCombinedArguments] = {
         name: ArgsMeCombinedArguments(
+            base_path / f"{name}.json",
             [arguments[subset_name] for subset_name in subset_names],
             namespace=f"{NAME}/{name}",
             language=language,

--- a/ir_datasets/datasets/argsme.py
+++ b/ir_datasets/datasets/argsme.py
@@ -1,8 +1,8 @@
 from itertools import chain
 from typing import Dict
 
-from ir_datasets import Dataset, registry
-from ir_datasets.datasets.base import YamlDocumentation
+from ir_datasets import registry
+from ir_datasets.datasets.base import Dataset, YamlDocumentation
 from ir_datasets.formats.argsme import ArgsMeArguments, ArgsMeCombinedArguments
 from ir_datasets.util import DownloadConfig, home_path, Cache, ZipExtract
 

--- a/ir_datasets/docs/argsme.yaml
+++ b/ir_datasets/docs/argsme.yaml
@@ -2,11 +2,8 @@ _:
   pretty_name: "args.me"
   desc: '
 <p>
-The args.me corpus comprises 387 740 arguments, crawled from Debatewise, IDebate.org, Debatepedia, Debate.org,
-and from Canadian Parliament discussions.
-</p>
-<p>
-This collection is licensed with the Creative Commons Attribution 4.0 International. Individual rights to the content still apply.
+The args.me corpus is one of the largest argument resources available
+and contains arguments crawled from debate platforms and parliament discussions.
 </p>
 <ul>
 <li><a href="https://args.me/">args.me Search Engine</a></li>
@@ -15,44 +12,109 @@ This collection is licensed with the Creative Commons Attribution 4.0 Internatio
 <li><a href="https://git.webis.de/code-research/arguana/args/args-framework">GitLab Repository</a></li>
 </ul>
 '
-  bibtex_ids: ['Wachsmuth2017Argument', 'Ajjour2019Acquisition']
+  bibtex_ids:
+    - 'Wachsmuth2017Argument'
+    - 'Ajjour2019Acquisition'
 
-debateorg:
+1.0:
+  pretty_name: "args.me version 1.0"
   desc: '
 <p>
-Subset of the 338 620 arguments that were crawled from the debate portal Debate.org.
+Corpus version 1.0 with 387 606 arguments crawled from Debatewise, IDebate.org, Debatepedia, Debate.org.
+It was released on July 9, 2019 on <a href="https://zenodo.org/record/3274636">Zenodo</a>.
+</p>
+<p>
+This collection is licensed with the
+<a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International</a>.
+Individual rights to the content still apply.
 </p>
 '
-  bibtex_ids: ['Wachsmuth2017Argument', 'Ajjour2019Acquisition']
+  bibtex_ids:
+    - 'Wachsmuth2017Argument'
+    - 'Ajjour2019Acquisition'
 
-debatepedia:
+1.0-cleaned:
+  pretty_name: "args.me version 1.0 cleaned"
   desc: '
 <p>
-Subset of the 21 197 arguments that were crawled from the debate portal Debatepedia.
+Corpus version 1.0-cleaned with 382 545 arguments crawled from Debatewise, IDebate.org, Debatepedia, Debate.org.
+This version contains the same arguments as version 1.0, but cleaned as described in the corresponding publication.
+It was released on October 27, 2020 on <a href="https://zenodo.org/record/4139439">Zenodo</a>.
+</p>
+<p>
+This collection is licensed with the
+<a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International</a>.
+Individual rights to the content still apply.
 </p>
 '
-  bibtex_ids: ['Wachsmuth2017Argument', 'Ajjour2019Acquisition']
+  bibtex_ids:
+    - 'Wachsmuth2017Argument'
+    - 'Ajjour2019Acquisition'
 
-debatewise:
+2020-04-01:
+  pretty_name: "args.me"
   desc: '
 <p>
-Subset of the 14 353 arguments that were crawled from the debate portal Debatewise.
+Corpus version 2020-04-01 with 387 740 arguments crawled from Debatewise, IDebate.org, Debatepedia, Debate.org,
+and from Canadian Parliament discussions.
+It was released on April 1, 2020 on <a href="https://zenodo.org/record/3734893">Zenodo</a>.
+</p>
+<p>
+This collection is licensed with the
+<a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International</a>.
+Individual rights to the content still apply.
 </p>
 '
-  bibtex_ids: ['Wachsmuth2017Argument', 'Ajjour2019Acquisition']
+  bibtex_ids:
+    - 'Wachsmuth2017Argument'
+    - 'Ajjour2019Acquisition'
 
-idebate:
+2020-04-01/debateorg:
   desc: '
 <p>
-Subset of the 13 522 arguments, that were crawled from the debate portal IDebate.org.
+Subset of the 338 620 arguments from args.me version 2020-04-01 that were crawled from the debate portal Debate.org.
 </p>
 '
-  bibtex_ids: ['Wachsmuth2017Argument', 'Ajjour2019Acquisition']
+  bibtex_ids:
+    - 'Wachsmuth2017Argument'
+    - 'Ajjour2019Acquisition'
 
-parliamentary:
+2020-04-01/debatepedia:
   desc: '
 <p>
-Subset of the 48 arguments, that were crawled from Canadian Parliament discussions.
+Subset of the 21 197 arguments from args.me version 2020-04-01 that were crawled from the debate portal Debatepedia.
 </p>
 '
-  bibtex_ids: ['Wachsmuth2017Argument', 'Ajjour2019Acquisition']
+  bibtex_ids:
+    - 'Wachsmuth2017Argument'
+    - 'Ajjour2019Acquisition'
+
+2020-04-01/debatewise:
+  desc: '
+<p>
+Subset of the 14 353 arguments from args.me version 2020-04-01 that were crawled from the debate portal Debatewise.
+</p>
+'
+  bibtex_ids:
+    - 'Wachsmuth2017Argument'
+    - 'Ajjour2019Acquisition'
+
+2020-04-01/idebate:
+  desc: '
+<p>
+Subset of the 13 522 arguments from args.me version 2020-04-01 that were crawled from the debate portal IDebate.org.
+</p>
+'
+  bibtex_ids:
+    - 'Wachsmuth2017Argument'
+    - 'Ajjour2019Acquisition'
+
+2020-04-01/parliamentary:
+  desc: '
+<p>
+Subset of the 48 arguments from args.me version 2020-04-01 that were crawled from Canadian Parliament discussions.
+</p>
+'
+  bibtex_ids:
+    - 'Wachsmuth2017Argument'
+    - 'Ajjour2019Acquisition'

--- a/ir_datasets/docs/argsme.yaml
+++ b/ir_datasets/docs/argsme.yaml
@@ -1,0 +1,58 @@
+_:
+  pretty_name: "args.me"
+  desc: '
+<p>
+The args.me corpus comprises 387 740 arguments, crawled from Debatewise, IDebate.org, Debatepedia, Debate.org,
+and from Canadian Parliament discussions.
+</p>
+<p>
+This collection is licensed with the Creative Commons Attribution 4.0 International. Individual rights to the content still apply.
+</p>
+<ul>
+<li><a href="https://args.me/">args.me Search Engine</a></li>
+<li><a href="https://webis.de/downloads/publications/papers/wachsmuth_2017f.pdf">args.me Search Engine Paper</a></li>
+<li><a href="https://webis.de/downloads/publications/papers/ajjour_2019a.pdf">args.me Corpus Paper</a></li>
+<li><a href="https://git.webis.de/code-research/arguana/args/args-framework">GitLab Repository</a></li>
+</ul>
+'
+  bibtex_ids: ['Wachsmuth2017Argument', 'Ajjour2019Acquisition']
+
+debateorg:
+  desc: '
+<p>
+Subset of the 338 620 arguments that were crawled from the debate portal Debate.org.
+</p>
+'
+  bibtex_ids: ['Wachsmuth2017Argument', 'Ajjour2019Acquisition']
+
+debatepedia:
+  desc: '
+<p>
+Subset of the 21 197 arguments that were crawled from the debate portal Debatepedia.
+</p>
+'
+  bibtex_ids: ['Wachsmuth2017Argument', 'Ajjour2019Acquisition']
+
+debatewise:
+  desc: '
+<p>
+Subset of the 14 353 arguments that were crawled from the debate portal Debatewise.
+</p>
+'
+  bibtex_ids: ['Wachsmuth2017Argument', 'Ajjour2019Acquisition']
+
+idebate:
+  desc: '
+<p>
+Subset of the 13 522 arguments, that were crawled from the debate portal IDebate.org.
+</p>
+'
+  bibtex_ids: ['Wachsmuth2017Argument', 'Ajjour2019Acquisition']
+
+parliamentary:
+  desc: '
+<p>
+Subset of the 48 arguments, that were crawled from Canadian Parliament discussions.
+</p>
+'
+  bibtex_ids: ['Wachsmuth2017Argument', 'Ajjour2019Acquisition']

--- a/ir_datasets/docs/bibliography.bib
+++ b/ir_datasets/docs/bibliography.bib
@@ -691,3 +691,32 @@
   booktitle={InfoScale},
   year={2006}
 }
+
+@inproceedings{Wachsmuth2017Argument,
+  author = {Henning Wachsmuth and Martin Potthast and Khalid Al-Khatib and Yamen Ajjour and Jana Puschmann and Jiani Qu and Jonas Dorsch and Viorel Morari and Janek Bevendorff and Benno Stein},
+  booktitle = {4th Workshop on Argument Mining (ArgMining 2017) at EMNLP},
+  editor = {Kevin Ashley and Claire Cardie and Nancy Green and Iryna Gurevych and Ivan Habernal and Diane Litman and Georgios Petasis and Chris Reed and Noam Slonim and Vern Walker},
+  ids = {potthast:2017k,stein:2017r},
+  month = sep,
+  pages = {49-59},
+  publisher = {Association for Computational Linguistics},
+  site = {Copenhagen, Denmark},
+  title = {{Building an Argument Search Engine for the Web}},
+  url = {https://www.aclweb.org/anthology/W17-5106},
+  year = 2017
+}
+
+@inproceedings{Ajjour2019Acquisition,
+  address = {Berlin Heidelberg New York},
+  author = {Yamen Ajjour and Henning Wachsmuth and Johannes Kiesel and Martin Potthast and Matthias Hagen and Benno Stein},
+  booktitle = {42nd German Conference on Artificial Intelligence (KI 2019)},
+  doi = {10.1007/978-3-030-30179-8\_4},
+  editor = {Christoph Benzm{\"u}ller and Heiner Stuckenschmidt},
+  ids = {potthast:2019m,stein:2019q},
+  month = sep,
+  pages = {48-59},
+  publisher = {Springer},
+  site = {Kassel, Germany},
+  title = {{Data Acquisition for Argument Search: The args.me corpus}},
+  year = 2019
+}

--- a/ir_datasets/etc/downloads.json
+++ b/ir_datasets/etc/downloads.json
@@ -76,6 +76,16 @@
 },
 
 "argsme": {
+  "1.0": {
+    "url": "https://zenodo.org/record/3274636/files/argsme.zip?download=1",
+    "size_hint": 238078064,
+    "expected_md5": "c2512648f46a403f8e5e1dc96779e357"
+  },
+  "1.0-cleaned": {
+    "url": "https://zenodo.org/record/4139439/files/argsme-1.0-cleaned.zip?download=1",
+    "size_hint": 236787622,
+    "expected_md5": "fb0837103a4860e1d4536174f55b12c3"
+  },
   "2020-04-01/debateorg": {
     "url": "https://zenodo.org/record/3734893/files/debateorg.zip?download=1",
     "size_hint": 1150846141,

--- a/ir_datasets/etc/downloads.json
+++ b/ir_datasets/etc/downloads.json
@@ -76,27 +76,27 @@
 },
 
 "argsme": {
-  "debateorg": {
+  "2020-04-01/debateorg": {
     "url": "https://zenodo.org/record/3734893/files/debateorg.zip?download=1",
     "size_hint": 1150846141,
     "expected_md5": "0368ee47ce0ec8bed837c7e22c024493"
   },
-  "debatepedia": {
+  "2020-04-01/debatepedia": {
     "url": "https://zenodo.org/record/3734893/files/debatepedia.zip?download=1",
     "size_hint": 184347726,
     "expected_md5": "bde8e3ed832c19ca5ed8ed1506a862e8"
   },
-  "debatewise": {
+  "2020-04-01/debatewise": {
     "url": "https://zenodo.org/record/3734893/files/debatewise.zip?download=1",
     "size_hint": 77388912,
     "expected_md5": "5e5c498a5f657ed7d02e06016e9ce3b1"
   },
-  "idebate": {
+  "2020-04-01/idebate": {
     "url": "https://zenodo.org/record/3734893/files/idebate.zip?download=1",
     "size_hint": 20241730,
     "expected_md5": "5b888c94cce740f1216c063e5e47c74c"
   },
-  "parliamentary": {
+  "2020-04-01/parliamentary": {
     "url": "https://zenodo.org/record/3734893/files/parliamentary.zip?download=1",
     "size_hint": 27319,
     "expected_md5": "c80d932c953b64fb300f13d0d93096bb"

--- a/ir_datasets/etc/downloads.json
+++ b/ir_datasets/etc/downloads.json
@@ -75,6 +75,34 @@
   }
 },
 
+"argsme": {
+  "debateorg": {
+    "url": "https://zenodo.org/record/3734893/files/debateorg.zip?download=1",
+    "size_hint": 1150846141,
+    "expected_md5": "0368ee47ce0ec8bed837c7e22c024493"
+  },
+  "debatepedia": {
+    "url": "https://zenodo.org/record/3734893/files/debatepedia.zip?download=1",
+    "size_hint": 184347726,
+    "expected_md5": "bde8e3ed832c19ca5ed8ed1506a862e8"
+  },
+  "debatewise": {
+    "url": "https://zenodo.org/record/3734893/files/debatewise.zip?download=1",
+    "size_hint": 77388912,
+    "expected_md5": "5e5c498a5f657ed7d02e06016e9ce3b1"
+  },
+  "idebate": {
+    "url": "https://zenodo.org/record/3734893/files/idebate.zip?download=1",
+    "size_hint": 20241730,
+    "expected_md5": "5b888c94cce740f1216c063e5e47c74c"
+  },
+  "parliamentary": {
+    "url": "https://zenodo.org/record/3734893/files/parliamentary.zip?download=1",
+    "size_hint": 27319,
+    "expected_md5": "c80d932c953b64fb300f13d0d93096bb"
+  }
+},
+
 "beir": {
   "msmarco": {
     "url": "https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/msmarco.zip",

--- a/ir_datasets/formats/__init__.py
+++ b/ir_datasets/formats/__init__.py
@@ -7,6 +7,6 @@ from .webarc import WarcDocs, WarcDoc
 from .ntcir import NtcirQrels
 from .clirmatrix import CLIRMatrixQueries, CLIRMatrixQrels
 from .argsme import (
-    ArgsMeArguments, ArgsMeArgument, ArgsMePremise, ArgsMeStance,
+    ArgsMeDocs, ArgsMeDoc, ArgsMePremise, ArgsMeStance,
     ArgsMePremiseAnnotation
 )

--- a/ir_datasets/formats/__init__.py
+++ b/ir_datasets/formats/__init__.py
@@ -7,6 +7,6 @@ from .webarc import WarcDocs, WarcDoc
 from .ntcir import NtcirQrels
 from .clirmatrix import CLIRMatrixQueries, CLIRMatrixQrels
 from .argsme import (
-    ArgsMeDocs, ArgsMeDoc, ArgsMePremise, ArgsMeStance,
-    ArgsMePremiseAnnotation
+    ArgsMeDocs, ArgsMeDoc, ArgsMeStance, ArgsMeMode, ArgsMeSourceDomain,
+    ArgsMePremise, ArgsMePremiseAnnotation, ArgsMeAspect
 )

--- a/ir_datasets/formats/__init__.py
+++ b/ir_datasets/formats/__init__.py
@@ -6,3 +6,7 @@ from .trec import TrecDocs, TrecQueries, TrecXmlQueries, TrecColonQueries, TrecQ
 from .webarc import WarcDocs, WarcDoc
 from .ntcir import NtcirQrels
 from .clirmatrix import CLIRMatrixQueries, CLIRMatrixQrels
+from .argsme import (
+    ArgsMeArguments, ArgsMeArgument, ArgsMePremise, ArgsMeStance,
+    ArgsMePremiseAnnotation
+)

--- a/ir_datasets/formats/argsme.py
+++ b/ir_datasets/formats/argsme.py
@@ -14,7 +14,7 @@ class ArgsMeStance(Enum):
     See the corresponding Java source files from the args.me project:
     https://git.webis.de/code-research/arguana/args/args-framework/-/blob/master/src/main/java/me/args/argument/Stance.java
     """
-    PRO = 2
+    PRO = 1
     CON = 2
 
     @staticmethod

--- a/ir_datasets/formats/argsme.py
+++ b/ir_datasets/formats/argsme.py
@@ -1,8 +1,8 @@
 from enum import Enum
 from itertools import chain
-from typing import NamedTuple, List, Any, Dict, Optional
+from json import load
+from typing import NamedTuple, List, Optional
 
-from ir_datasets import load
 from ir_datasets.formats import BaseDocs
 from ir_datasets.util import Cache
 
@@ -72,7 +72,6 @@ class ArgsMeArgument(NamedTuple):
     id: str
     conclusion: str
     premises: List[ArgsMePremise]
-    context: Dict[str, Any]
 
     @staticmethod
     def from_json(json: dict) -> "ArgsMeArgument":
@@ -83,7 +82,6 @@ class ArgsMeArgument(NamedTuple):
                 ArgsMePremise.from_json(premise)
                 for premise in json["premises"]
             ],
-            json["context"],
         )
 
 

--- a/ir_datasets/formats/argsme.py
+++ b/ir_datasets/formats/argsme.py
@@ -44,7 +44,7 @@ class ArgsMeMode(Enum):
 
 
 class ArgsMeSourceDomain(Enum):
-    debate_org = 1
+    debateorg = 1
     debatepedia = 2
     debatewise = 3
     idebate = 4
@@ -53,7 +53,7 @@ class ArgsMeSourceDomain(Enum):
     @staticmethod
     def from_json(json: str) -> "ArgsMeSourceDomain":
         if json == "debate.org":
-            return ArgsMeSourceDomain.debate_org
+            return ArgsMeSourceDomain.debateorg
         elif json == "debatepedia":
             return ArgsMeSourceDomain.debatepedia
         elif json == "debatewise":
@@ -200,22 +200,22 @@ class ArgsMeDoc(NamedTuple):
             else None
         )
         source_text_conclusion_start = (
-            str(context_json["sourceTextConclusionStart"])
+            int(context_json["sourceTextConclusionStart"])
             if "sourceTextConclusionStart" in context_json
             else None
         )
         source_text_conclusion_end = (
-            str(context_json["sourceTextConclusionEnd"])
+            int(context_json["sourceTextConclusionEnd"])
             if "sourceTextConclusionEnd" in context_json
             else None
         )
         source_text_premise_start = (
-            str(context_json["sourceTextPremiseStart"])
+            int(context_json["sourceTextPremiseStart"])
             if "sourceTextPremiseStart" in context_json
             else None
         )
         source_text_premise_end = (
-            str(context_json["sourceTextPremiseEnd"])
+            int(context_json["sourceTextPremiseEnd"])
             if "sourceTextPremiseEnd" in context_json
             else None
         )

--- a/ir_datasets/formats/argsme.py
+++ b/ir_datasets/formats/argsme.py
@@ -1,0 +1,99 @@
+from enum import Enum
+from typing import NamedTuple, List, Any, Dict, Optional
+
+from ir_datasets import load
+from ir_datasets.formats import BaseDocs
+from ir_datasets.util import Cache
+
+
+class ArgsMeStance(Enum):
+    """
+    See the corresponding Java source files from the args.me project:
+    https://git.webis.de/code-research/arguana/args/args-framework/-/blob/master/src/main/java/me/args/argument/Stance.java
+    """
+    PRO = 2
+    CON = 2
+
+    @staticmethod
+    def from_json(json: dict) -> "ArgsMeStance":
+        raise NotImplementedError()
+
+
+class ArgsMePremiseAnnotation(NamedTuple):
+    """
+    See the corresponding Java source files from the args.me project:
+    https://git.webis.de/code-research/arguana/args/args-framework/-/blob/master/src/main/java/me/args/argument/PremiseAnnotation.java
+    """
+    start: int
+    end: int
+    source: str
+
+    @staticmethod
+    def from_json(json: dict) -> "ArgsMePremiseAnnotation":
+        raise NotImplementedError()
+
+
+class ArgsMePremise(NamedTuple):
+    """
+    See the corresponding Java source files from the args.me project:
+    https://git.webis.de/code-research/arguana/args/args-framework/-/blob/master/src/main/java/me/args/argument/Premise.java
+    """
+    text: str
+    stance: ArgsMeStance
+    annotations: ArgsMePremiseAnnotation
+
+    @staticmethod
+    def from_json(json: dict) -> "ArgsMePremise":
+        raise NotImplementedError()
+
+
+class ArgsMeArgument(NamedTuple):
+    """
+    See the corresponding Java source files from the args.me project:
+    https://git.webis.de/code-research/arguana/args/args-framework/-/blob/master/src/main/java/me/args/Argument.java
+    """
+    id: str
+    conclusion: str
+    premises: List[ArgsMePremise]
+    context: Dict[str, Any]
+
+    @staticmethod
+    def from_json(json: dict) -> "ArgsMeArgument":
+        raise NotImplementedError()
+
+
+class ArgsMeArguments(BaseDocs):
+    _source: Cache
+    _namespace: Optional[str]
+    _language: Optional[str]
+    _count_hint: Optional[int]
+
+    def __init__(
+            self,
+            cache: Cache,
+            namespace: Optional[str] = None,
+            language: Optional[str] = None,
+            count_hint: Optional[int] = None,
+    ):
+        self._source = cache
+        self._namespace = namespace
+        self._language = language
+        self._count_hint = count_hint
+
+    def docs_iter(self):
+        with self._source.stream() as json_stream:
+            with load(json_stream) as arguments_json:
+                for argument_json in arguments_json:
+                    yield ArgsMeArgument.from_json(argument_json)
+
+    def docs_count(self):
+        return self._count_hint
+
+    def docs_cls(self):
+        return ArgsMeArgument
+
+    def docs_namespace(self):
+        return self._namespace
+
+    def docs_lang(self):
+        return self._language

--- a/ir_datasets/formats/argsme.py
+++ b/ir_datasets/formats/argsme.py
@@ -1,5 +1,7 @@
+from datetime import datetime
 from enum import Enum
 from pathlib import Path
+from re import sub
 from typing import NamedTuple, List, Optional
 
 from ijson import items
@@ -21,10 +23,47 @@ class ArgsMeStance(Enum):
     def from_json(json: str) -> "ArgsMeStance":
         if json == "PRO":
             return ArgsMeStance.PRO
-        if json == "CON":
+        elif json == "CON":
             return ArgsMeStance.CON
         else:
             raise ValueError(f"Unknown stance {json}")
+
+
+class ArgsMeMode(Enum):
+    person = 1
+    discussion = 2
+
+    @staticmethod
+    def from_json(json: str) -> "ArgsMeMode":
+        if json == "person":
+            return ArgsMeMode.person
+        elif json == "discussion":
+            return ArgsMeMode.discussion
+        else:
+            raise ValueError(f"Unknown mode {json}")
+
+
+class ArgsMeSourceDomain(Enum):
+    debate_org = 1
+    debatepedia = 2
+    debatewise = 3
+    idebate = 4
+    canadian_parliament = 5
+
+    @staticmethod
+    def from_json(json: str) -> "ArgsMeSourceDomain":
+        if json == "debate.org":
+            return ArgsMeSourceDomain.debate_org
+        elif json == "debatepedia":
+            return ArgsMeSourceDomain.debatepedia
+        elif json == "debatewise":
+            return ArgsMeSourceDomain.debatewise
+        elif json == "idebate":
+            return ArgsMeSourceDomain.idebate
+        elif json == "canadian-parliament":
+            return ArgsMeSourceDomain.canadian_parliament
+        else:
+            raise ValueError(f"Unknown source domain {json}")
 
 
 class ArgsMePremiseAnnotation(NamedTuple):
@@ -38,11 +77,10 @@ class ArgsMePremiseAnnotation(NamedTuple):
 
     @staticmethod
     def from_json(json: dict) -> "ArgsMePremiseAnnotation":
-        return ArgsMePremiseAnnotation(
-            int(json["start"]),
-            int(json["end"]),
-            str(json["source"]),
-        )
+        start = int(json["start"])
+        end = int(json["end"])
+        source = str(json["source"])
+        return ArgsMePremiseAnnotation(start, end, source)
 
 
 class ArgsMePremise(NamedTuple):
@@ -66,24 +104,190 @@ class ArgsMePremise(NamedTuple):
         )
 
 
+class ArgsMeAspect(NamedTuple):
+    name: str
+    weight: float
+    normalized_weight: float
+    rank: int
+
+    @staticmethod
+    def from_json(json: dict) -> "ArgsMeAspect":
+        name = str(json["name"])
+        weight = float(json["weight"])
+        normalized_weight = float(json["normalizedWeight"])
+        rank = int(json["rank"])
+        return ArgsMeAspect(name, weight, normalized_weight, rank)
+
+
 class ArgsMeDoc(NamedTuple):
     """
     See the corresponding Java source files from the args.me project:
     https://git.webis.de/code-research/arguana/args/args-framework/-/blob/master/src/main/java/me/args/Argument.java
+    https://git.webis.de/code-research/arguana/args/args-framework/-/blob/master/src/main/java/me/args/argument/Premise.java
     """
     doc_id: str
     conclusion: str
     premises: List[ArgsMePremise]
+    premises_texts: str  # Premises texts concatenated with spaces.
+    aspects: List[ArgsMeAspect]
+    aspects_names: str  # Aspects namews concatenated with spaces.
+    source_id: str
+    source_title: str
+    source_url: Optional[str]
+    source_previous_argument_id: Optional[str]
+    source_next_argument_id: Optional[str]
+    source_domain: Optional[ArgsMeSourceDomain]
+    source_text: Optional[str]
+    source_text_conclusion_start: Optional[int]
+    source_text_conclusion_end: Optional[int]
+    source_text_premise_start: Optional[int]
+    source_text_premise_end: Optional[int]
+    topic: str  # Topic or discussion title.
+    acquisition: datetime
+    date: Optional[datetime]
+    author: Optional[str]
+    author_image_url: Optional[str]
+    author_organization: Optional[str]
+    author_role: Optional[str]
+    mode: Optional[ArgsMeMode]
 
     @staticmethod
     def from_json(json: dict) -> "ArgsMeDoc":
+        context_json = json["context"]
+
+        doc_id = str(json["id"])
+        conclusion = str(json["conclusion"])
+
+        premises = [
+            ArgsMePremise.from_json(premise)
+            for premise in json["premises"]
+        ]
+        premises_texts = " ".join(premise.text for premise in premises)
+
+        aspects = [
+            ArgsMeAspect.from_json(aspect)
+            for aspect in context_json["aspects"]
+        ] if "aspects" in context_json else []
+        aspects_names = " ".join(aspect.name for aspect in aspects)
+
+        source_id = str(context_json["sourceId"])
+        source_title = str(context_json["sourceTitle"])
+        source_url = (
+            str(context_json["sourceUrl"])
+            if "sourceUrl" in context_json
+            else None
+        )
+        source_previous_argument_id = (
+            str(context_json["previousArgumentInSourceId"])
+            if ("previousArgumentInSourceId" in context_json and
+                context_json["previousArgumentInSourceId"])
+            else None
+        )
+        source_next_argument_id = (
+            str(context_json["nextArgumentInSourceId"])
+            if ("nextArgumentInSourceId" in context_json and
+                context_json["nextArgumentInSourceId"])
+            else None
+        )
+        source_domain = (
+            ArgsMeSourceDomain.from_json(context_json["sourceDomain"])
+            if "sourceDomain" in context_json
+            else None
+        )
+        source_text = (
+            str(context_json["sourceText"])
+            if "sourceText" in context_json
+            else None
+        )
+        source_text_conclusion_start = (
+            str(context_json["sourceTextConclusionStart"])
+            if "sourceTextConclusionStart" in context_json
+            else None
+        )
+        source_text_conclusion_end = (
+            str(context_json["sourceTextConclusionEnd"])
+            if "sourceTextConclusionEnd" in context_json
+            else None
+        )
+        source_text_premise_start = (
+            str(context_json["sourceTextPremiseStart"])
+            if "sourceTextPremiseStart" in context_json
+            else None
+        )
+        source_text_premise_end = (
+            str(context_json["sourceTextPremiseEnd"])
+            if "sourceTextPremiseEnd" in context_json
+            else None
+        )
+
+        topic = (
+            str(context_json["topic"])
+            if "topic" in context_json
+            else str(context_json["discussionTitle"])
+        )
+        acquisition = datetime.fromisoformat(
+            sub(r"Z$", "+00:00", context_json["acquisitionTime"])
+        )
+        date = (
+            datetime.fromisoformat(
+                sub(r"Z$", "+00:00", context_json["date"])
+            )
+            if "date" in context_json
+            else None
+        )
+
+        author = (
+            str(context_json["author"])
+            if "author" in context_json
+            else None
+        )
+        author_image_url = (
+            str(context_json["authorImage"])
+            if "authorImage" in context_json
+            else None
+        )
+        author_organization = (
+            str(context_json["authorOrganization"])
+            if "authorOrganization" in context_json
+            else None
+        )
+        author_role = (
+            str(context_json["authorRole"])
+            if "authorRole" in context_json
+            else None
+        )
+        mode = (
+            ArgsMeMode.from_json(context_json["mode"])
+            if "mode" in context_json
+            else None
+        )
+
         return ArgsMeDoc(
-            str(json["id"]),
-            str(json["conclusion"]),
-            [
-                ArgsMePremise.from_json(premise)
-                for premise in json["premises"]
-            ],
+            doc_id=doc_id,
+            conclusion=conclusion,
+            premises=premises,
+            premises_texts=premises_texts,
+            aspects=aspects,
+            aspects_names=aspects_names,
+            source_id=source_id,
+            source_title=source_title,
+            source_url=source_url,
+            source_previous_argument_id=source_previous_argument_id,
+            source_next_argument_id=source_next_argument_id,
+            source_domain=source_domain,
+            source_text=source_text,
+            source_text_conclusion_start=source_text_conclusion_start,
+            source_text_conclusion_end=source_text_conclusion_end,
+            source_text_premise_start=source_text_premise_start,
+            source_text_premise_end=source_text_premise_end,
+            topic=topic,
+            acquisition=acquisition,
+            date=date,
+            author=author,
+            author_image_url=author_image_url,
+            author_organization=author_organization,
+            author_role=author_role,
+            mode=mode,
         )
 
 

--- a/ir_datasets/formats/argsme.py
+++ b/ir_datasets/formats/argsme.py
@@ -6,7 +6,7 @@ from ijson import items
 
 from ir_datasets.formats import BaseDocs
 from ir_datasets.indices import PickleLz4FullStore
-from ir_datasets.util import Cache
+from ir_datasets.util import Cache, use_docstore
 
 
 class ArgsMeStance(Enum):
@@ -108,6 +108,7 @@ class ArgsMeDocs(BaseDocs):
     def docs_path(self):
         return self._source.path()
 
+    @use_docstore
     def docs_iter(self):
         with self._source.stream() as json_stream:
             argument_jsons = items(json_stream, "arguments.item")
@@ -162,6 +163,7 @@ class ArgsMeCombinedArguments(BaseDocs):
     def docs_path(self):
         return self._path
 
+    @use_docstore
     def docs_iter(self):
         for source in self._sources:
             for argument in source.docs_iter():

--- a/ir_datasets/formats/argsme.py
+++ b/ir_datasets/formats/argsme.py
@@ -4,8 +4,7 @@ from pathlib import Path
 from re import sub
 from typing import NamedTuple, List, Optional
 
-from ijson import items
-
+from ir_datasets import lazy_libs
 from ir_datasets.formats import BaseDocs
 from ir_datasets.indices import PickleLz4FullStore
 from ir_datasets.util import Cache, use_docstore
@@ -314,8 +313,9 @@ class ArgsMeDocs(BaseDocs):
 
     @use_docstore
     def docs_iter(self):
+        ijson = lazy_libs.ijson()
         with self._source.stream() as json_stream:
-            argument_jsons = items(json_stream, "arguments.item")
+            argument_jsons = ijson.items(json_stream, "arguments.item")
             for argument_json in argument_jsons:
                 argument = ArgsMeDoc.from_json(argument_json)
                 yield argument

--- a/ir_datasets/formats/argsme.py
+++ b/ir_datasets/formats/argsme.py
@@ -62,7 +62,7 @@ class ArgsMePremise(NamedTuple):
             [
                 ArgsMePremiseAnnotation.from_json(annotation)
                 for annotation in json["annotations"]
-            ],
+            ] if "annotations" in json else [],
         )
 
 

--- a/ir_datasets/formats/argsme.py
+++ b/ir_datasets/formats/argsme.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from itertools import chain
 from typing import NamedTuple, List, Any, Dict, Optional
 
 from ir_datasets import load
@@ -96,4 +97,57 @@ class ArgsMeArguments(BaseDocs):
         return self._namespace
 
     def docs_lang(self):
+        return self._language
+
+
+class ArgsMeCombinedArguments(BaseDocs):
+    _sources: List[ArgsMeArguments]
+    _namespace: Optional[str]
+    _language: Optional[str]
+    _count_hint: Optional[int]
+
+    def __init__(
+            self,
+            sources: List[ArgsMeArguments],
+            namespace: Optional[str] = None,
+            language: Optional[str] = None,
+            count_hint: Optional[int] = None,
+    ):
+        self._sources = sources
+        self._namespace = namespace
+        self._language = language
+        self._count_hint = count_hint
+
+    def docs_iter(self):
+        return chain(
+            source.docs_iter()
+            for source in self._sources
+        )
+
+    def docs_count(self):
+        assert (sum(
+            source.docs_count()
+            for source in self._sources
+        ) == self._count_hint)
+        return self._count_hint
+
+    def docs_cls(self):
+        assert (all(
+            source.docs_cls() == ArgsMeArgument
+            for source in self._sources
+        ))
+        return ArgsMeArgument
+
+    def docs_namespace(self):
+        assert (all(
+            source.docs_namespace() in self._namespace
+            for source in self._sources
+        ))
+        return self._namespace
+
+    def docs_lang(self):
+        assert (all(
+            source.docs_lang() == self._language
+            for source in self._sources
+        ))
         return self._language

--- a/ir_datasets/formats/argsme.py
+++ b/ir_datasets/formats/argsme.py
@@ -1,7 +1,8 @@
 from enum import Enum
 from itertools import chain
-from json import load
 from typing import NamedTuple, List, Optional
+
+from ijson import items
 
 from ir_datasets.formats import BaseDocs
 from ir_datasets.util import Cache
@@ -105,9 +106,10 @@ class ArgsMeArguments(BaseDocs):
 
     def docs_iter(self):
         with self._source.stream() as json_stream:
-            with load(json_stream) as arguments_json:
-                for argument_json in arguments_json:
-                    yield ArgsMeArgument.from_json(argument_json)
+            argument_jsons = items(json_stream, "arguments.item")
+            for argument_json in argument_jsons:
+                argument = ArgsMeArgument.from_json(argument_json)
+                yield argument
 
     def docs_count(self):
         return self._count_hint

--- a/ir_datasets/formats/argsme.py
+++ b/ir_datasets/formats/argsme.py
@@ -16,8 +16,13 @@ class ArgsMeStance(Enum):
     CON = 2
 
     @staticmethod
-    def from_json(json: dict) -> "ArgsMeStance":
-        raise NotImplementedError()
+    def from_json(json: str) -> "ArgsMeStance":
+        if json == "PRO":
+            return ArgsMeStance.PRO
+        if json == "CON":
+            return ArgsMeStance.CON
+        else:
+            raise ValueError(f"Unknown stance {json}")
 
 
 class ArgsMePremiseAnnotation(NamedTuple):
@@ -31,7 +36,11 @@ class ArgsMePremiseAnnotation(NamedTuple):
 
     @staticmethod
     def from_json(json: dict) -> "ArgsMePremiseAnnotation":
-        raise NotImplementedError()
+        return ArgsMePremiseAnnotation(
+            int(json["start"]),
+            int(json["end"]),
+            str(json["source"]),
+        )
 
 
 class ArgsMePremise(NamedTuple):
@@ -41,11 +50,18 @@ class ArgsMePremise(NamedTuple):
     """
     text: str
     stance: ArgsMeStance
-    annotations: ArgsMePremiseAnnotation
+    annotations: List[ArgsMePremiseAnnotation]
 
     @staticmethod
     def from_json(json: dict) -> "ArgsMePremise":
-        raise NotImplementedError()
+        return ArgsMePremise(
+            str(json["text"]),
+            ArgsMeStance.from_json(json["stance"]),
+            [
+                ArgsMePremiseAnnotation.from_json(annotation)
+                for annotation in json["annotations"]
+            ],
+        )
 
 
 class ArgsMeArgument(NamedTuple):
@@ -60,7 +76,15 @@ class ArgsMeArgument(NamedTuple):
 
     @staticmethod
     def from_json(json: dict) -> "ArgsMeArgument":
-        raise NotImplementedError()
+        return ArgsMeArgument(
+            str(json["id"]),
+            str(json["conclusion"]),
+            [
+                ArgsMePremise.from_json(premise)
+                for premise in json["premises"]
+            ],
+            json["context"],
+        )
 
 
 class ArgsMeArguments(BaseDocs):

--- a/test/integration/argsme.py
+++ b/test/integration/argsme.py
@@ -1,0 +1,27 @@
+from unittest import main
+
+from test.integration.base import DatasetIntegrationTest
+
+
+class TestArgsMe(DatasetIntegrationTest):
+    def test_docs(self):
+        self._test_docs('argsme/1.0', count=387692, items={
+        })
+        self._test_docs('argsme/1.0-cleaned', count=382545, items={
+        })
+        self._test_docs('argsme/2020-04-01', count=387740, items={
+        })
+        self._test_docs('argsme/2020-04-01/debateorg', count=338620, items={
+        })
+        self._test_docs('argsme/2020-04-01/debatepedia', count=21197, items={
+        })
+        self._test_docs('argsme/2020-04-01/debatewise', count=14353, items={
+        })
+        self._test_docs('argsme/2020-04-01/idebate', count=13522, items={
+        })
+        self._test_docs('argsme/2020-04-01/parliamentary', count=48, items={
+        })
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/argsme.py
+++ b/test/integration/argsme.py
@@ -51,7 +51,7 @@ class TestArgsMe(DatasetIntegrationTest):
                     )
                 ]
             ),
-        }, test_iter_split=False)
+        })
         self._test_docs('argsme/1.0-cleaned', count=382545, items={
             0: ArgsMeDoc(
                 doc_id="c67482ba-2019-04-18T13:32:05Z-00000-000",
@@ -97,7 +97,7 @@ class TestArgsMe(DatasetIntegrationTest):
                     )
                 ]
             ),
-        }, test_iter_split=False)
+        })
         self._test_docs('argsme/2020-04-01', count=387740, items={
             0: ArgsMeDoc(
                 doc_id="Sb38112c8-A443a9828",
@@ -143,7 +143,7 @@ class TestArgsMe(DatasetIntegrationTest):
                     )
                 ]
             ),
-        }, test_iter_split=False)
+        })
         self._test_docs('argsme/2020-04-01/debateorg', count=338620, items={
             0: ArgsMeDoc(
                 doc_id="Sb38112c8-A443a9828",
@@ -189,7 +189,7 @@ class TestArgsMe(DatasetIntegrationTest):
                     )
                 ]
             ),
-        }, test_iter_split=False)
+        })
         self._test_docs('argsme/2020-04-01/debatepedia', count=21197, items={
             0: ArgsMeDoc(
                 doc_id="S96f2396e-Aaf079b43",
@@ -235,7 +235,7 @@ class TestArgsMe(DatasetIntegrationTest):
                     )
                 ]
             ),
-        }, test_iter_split=False)
+        })
         self._test_docs('argsme/2020-04-01/debatewise', count=14353, items={
             0: ArgsMeDoc(
                 doc_id="S5920cdef-A982becb7",
@@ -281,7 +281,7 @@ class TestArgsMe(DatasetIntegrationTest):
                     )
                 ]
             ),
-        }, test_iter_split=False)
+        })
         self._test_docs('argsme/2020-04-01/idebate', count=13522, items={
             0: ArgsMeDoc(
                 doc_id="Sf9294c83-Af186e851",
@@ -327,7 +327,7 @@ class TestArgsMe(DatasetIntegrationTest):
                     )
                 ]
             ),
-        }, test_iter_split=False)
+        })
         self._test_docs('argsme/2020-04-01/parliamentary', count=48, items={
             0: ArgsMeDoc(
                 doc_id="S1f6b58eb-A5c530110",
@@ -373,7 +373,7 @@ class TestArgsMe(DatasetIntegrationTest):
                     )
                 ]
             ),
-        }, test_iter_split=False)
+        })
 
 
 if __name__ == '__main__':

--- a/test/integration/argsme.py
+++ b/test/integration/argsme.py
@@ -1,44 +1,48 @@
+from datetime import datetime
 from unittest import main
+from re import compile
 
-from ir_datasets.formats import ArgsMeDoc, ArgsMePremise, ArgsMeStance
+from ir_datasets.formats import ArgsMeDoc, ArgsMeStance, ArgsMePremise, \
+    ArgsMeSourceDomain, ArgsMeMode, ArgsMeAspect
 from test.integration.base import DatasetIntegrationTest
-
 
 class TestArgsMe(DatasetIntegrationTest):
     def test_docs(self):
+        # noinspection PyTypeChecker
         self._test_docs('argsme/1.0', count=387692, items={
             0: ArgsMeDoc(
                 doc_id="c67482ba-2019-04-18T13:32:05Z-00000-000",
                 conclusion="Contraceptive Forms for High School Students",
                 premises=[
                     ArgsMePremise(
-                        text="My opponent forfeited every round. None of my arguments were answered. I don’t like the idea of winning by default, but here we are.Tule: it’s good for students to get involved and address big issues like teen pregnancy. You need to be able to answer arguments like mine and not simply prepare for an abstinence-only type of response. You should also be aware that, in the U.S., condoms may be sold to minors in ANY state. A retailer who says it is illegal to sell you them is, frankly, wrong.",
+                        text=compile("My opponent forfeited every round\. None of my argu.{393}it is illegal to sell you them is, frankly, wrong\."),
                         stance=ArgsMeStance.CON,
-                        annotations=[]
-                    )
-                ]
-            ),
-            1: ArgsMeDoc(
-                doc_id="c67482ba-2019-04-18T13:32:05Z-00001-000",
-                conclusion="Contraceptive Forms for High School Students",
-                premises=[
-                    ArgsMePremise(
-                        text="How do you propose the school will fund your program? Condoms cost money and checking an \"opt out\" list before handing them out takes time away from staff members whenever they could be doing their actual jobs. Your \"opt out\" option is only be a token to parental authority and would be easily subverted. If everyone in school except a handful of students had access to free condoms, do you not think those students would simply ask their friends to provide them with condoms?",
-                        stance=ArgsMeStance.CON,
-                        annotations=[]
-                    )
-                ]
-            ),
-            387690: ArgsMeDoc(
-                doc_id="671509c8-2019-04-17T11:47:34Z-00022-000",
-                conclusion="Charter schools",
-                premises=[
-                    ArgsMePremise(
-                        text="Charter schools are damaging private schools",
-                        stance=ArgsMeStance.CON,
-                        annotations=[]
-                    )
-                ]
+                        annotations=[],
+                    ),
+                ],
+                premises_texts=compile("My opponent forfeited every round\. None of my argu.{393}it is illegal to sell you them is, frankly, wrong\."),
+                aspects=[],
+                aspects_names="",
+                source_id="c67482ba-2019-04-18T13:32:05Z",
+                source_title="Debate Argument: Contraceptive Forms for High School Students | Debate.org",
+                source_url="https://www.debate.org/debates/Contraceptive-Forms-for-High-School-Students/1/",
+                source_previous_argument_id=None,
+                source_next_argument_id="c67482ba-2019-04-18T13:32:05Z-00001-000",
+                source_domain=None,
+                source_text=None,
+                source_text_conclusion_start=None,
+                source_text_conclusion_end=None,
+                source_text_premise_start=None,
+                source_text_premise_end=None,
+                topic="Contraceptive Forms for High School Students",
+                acquisition=datetime.fromisoformat(
+                    "2019-04-18T13:32:05+00:00"),
+                date=None,
+                author=None,
+                author_image_url=None,
+                author_organization=None,
+                author_role=None,
+                mode=None,
             ),
             387691: ArgsMeDoc(
                 doc_id="671509c8-2019-04-17T11:47:34Z-00007-000",
@@ -47,9 +51,31 @@ class TestArgsMe(DatasetIntegrationTest):
                     ArgsMePremise(
                         text="Charter schools are exploited most by affable students",
                         stance=ArgsMeStance.CON,
-                        annotations=[]
-                    )
-                ]
+                        annotations=[],
+                    ),
+                ],
+                premises_texts="Charter schools are exploited most by affable students",
+                aspects=[],
+                aspects_names="",
+                source_id="671509c8-2019-04-17T11:47:34Z",
+                source_title="Debate: Charter schools - Debatepedia",
+                source_url="http://www.debatepedia.org/en/index.php/Debate:_Charter_schools",
+                source_previous_argument_id="671509c8-2019-04-17T11:47:34Z-00022-000",
+                source_next_argument_id="671509c8-2019-04-17T11:47:34Z-00057-000",
+                source_domain=None,
+                source_text=None,
+                source_text_conclusion_start=None,
+                source_text_conclusion_end=None,
+                source_text_premise_start=None,
+                source_text_premise_end=None,
+                topic="Charter schools",
+                acquisition=datetime.fromisoformat("2019-04-17T11:47:34+00:00"),
+                date=None,
+                author=None,
+                author_image_url=None,
+                author_organization=None,
+                author_role=None,
+                mode=None,
             ),
         })
         self._test_docs('argsme/1.0-cleaned', count=382545, items={
@@ -58,33 +84,33 @@ class TestArgsMe(DatasetIntegrationTest):
                 conclusion="Contraceptive Forms for High School Students",
                 premises=[
                     ArgsMePremise(
-                        text="My opponent forfeited every round. None of my arguments were answered. I don’t like the idea of winning by default, but here we are.Tule: it’s good for students to get involved and address big issues like teen pregnancy. You need to be able to answer arguments like mine and not simply prepare for an abstinence-only type of response. You should also be aware that, in the U.S., condoms may be sold to minors in ANY state. A retailer who says it is illegal to sell you them is, frankly, wrong.",
+                        text=compile("My opponent forfeited every round\. None of my argu.{393}it is illegal to sell you them is, frankly, wrong\."),
                         stance=ArgsMeStance.CON,
-                        annotations=[]
-                    )
-                ]
-            ),
-            1: ArgsMeDoc(
-                doc_id="c67482ba-2019-04-18T13:32:05Z-00001-000",
-                conclusion="Contraceptive Forms for High School Students",
-                premises=[
-                    ArgsMePremise(
-                        text="How do you propose the school will fund your program? Condoms cost money and checking an \"opt out\" list before handing them out takes time away from staff members whenever they could be doing their actual jobs. Your \"opt out\" option is only be a token to parental authority and would be easily subverted. If everyone in school except a handful of students had access to free condoms, do you not think those students would simply ask their friends to provide them with condoms?",
-                        stance=ArgsMeStance.CON,
-                        annotations=[]
-                    )
-                ]
-            ),
-            382543: ArgsMeDoc(
-                doc_id="671509c8-2019-04-17T11:47:34Z-00022-000",
-                conclusion="Charter schools",
-                premises=[
-                    ArgsMePremise(
-                        text="Charter schools are damaging private schools",
-                        stance=ArgsMeStance.CON,
-                        annotations=[]
-                    )
-                ]
+                        annotations=[],
+                    ),
+                ],
+                premises_texts=compile("My opponent forfeited every round\. None of my argu.{393}it is illegal to sell you them is, frankly, wrong\."),
+                aspects=[],
+                aspects_names="",
+                source_id="c67482ba-2019-04-18T13:32:05Z",
+                source_title="Debate Argument: Contraceptive Forms for High School Students | Debate.org",
+                source_url="https://www.debate.org/debates/Contraceptive-Forms-for-High-School-Students/1/",
+                source_previous_argument_id=None,
+                source_next_argument_id="c67482ba-2019-04-18T13:32:05Z-00001-000",
+                source_domain=None,
+                source_text=None,
+                source_text_conclusion_start=None,
+                source_text_conclusion_end=None,
+                source_text_premise_start=None,
+                source_text_premise_end=None,
+                topic="Contraceptive Forms for High School Students",
+                acquisition=datetime.fromisoformat("2019-04-18T13:32:05+00:00"),
+                date=None,
+                author=None,
+                author_image_url=None,
+                author_organization=None,
+                author_role=None,
+                mode=None,
             ),
             382544: ArgsMeDoc(
                 doc_id="671509c8-2019-04-17T11:47:34Z-00007-000",
@@ -93,9 +119,31 @@ class TestArgsMe(DatasetIntegrationTest):
                     ArgsMePremise(
                         text="Charter schools are exploited most by affable students",
                         stance=ArgsMeStance.CON,
-                        annotations=[]
-                    )
-                ]
+                        annotations=[],
+                    ),
+                ],
+                premises_texts="Charter schools are exploited most by affable students",
+                aspects=[],
+                aspects_names="",
+                source_id="671509c8-2019-04-17T11:47:34Z",
+                source_title="Debate: Charter schools - Debatepedia",
+                source_url="http://www.debatepedia.org/en/index.php/Debate:_Charter_schools",
+                source_previous_argument_id="671509c8-2019-04-17T11:47:34Z-00022-000",
+                source_next_argument_id="671509c8-2019-04-17T11:47:34Z-00057-000",
+                source_domain=None,
+                source_text=None,
+                source_text_conclusion_start=None,
+                source_text_conclusion_end=None,
+                source_text_premise_start=None,
+                source_text_premise_end=None,
+                topic="Charter schools",
+                acquisition=datetime.fromisoformat("2019-04-17T11:47:34+00:00"),
+                date=None,
+                author=None,
+                author_image_url=None,
+                author_organization=None,
+                author_role=None,
+                mode=None,
             ),
         })
         self._test_docs('argsme/2020-04-01', count=387740, items={
@@ -106,42 +154,71 @@ class TestArgsMe(DatasetIntegrationTest):
                     ArgsMePremise(
                         text="Done.",
                         stance=ArgsMeStance.PRO,
-                        annotations=[]
-                    )
-                ]
-            ),
-            1: ArgsMeDoc(
-                doc_id="Sb38112c8-A48f87c39",
-                conclusion="school",
-                premises=[
-                    ArgsMePremise(
-                        text="Let's get this over with.",
-                        stance=ArgsMeStance.PRO,
-                        annotations=[]
-                    )
-                ]
-            ),
-            387738: ArgsMeDoc(
-                doc_id="S18eb2e1a-Afe2ebde7",
-                conclusion="Single female seniors are particularly challenged.",
-                premises=[
-                    ArgsMePremise(
-                        text="Canada's economy may be doing well, but across the country there are millions of Canadians who live in poverty. This is especially true for women and children, as has been reported across the country today. Single female seniors are particularly challenged. One report provides the example of a single female senior who, having worked all her life to raise her three children, has had to give up her car, buy second-hand clothes and live on combined benefits of $16,000 per year. The United Nations agency for children, UNICEF, reports that in Canada “our children are suffering from unacceptable rates of poverty”. The levels of poverty in this country, especially for women and children, are totally unacceptable. The Leader of the Opposition has recently outlined real and meaningful plans to deal with the issue of poverty in Canada, but from the government we hear nothing. That is an absolute shame. Canadians deserve better.",
-                        stance=ArgsMeStance.CON,
-                        annotations=[]
-                    )
-                ]
+                        annotations=[],
+                    ),
+                ],
+                premises_texts="Done.",
+                aspects=[],
+                aspects_names="",
+                source_id="Sb38112c8",
+                source_title="Debate: school | Debate.org",
+                source_url="https://www.debate.org/debates/school/3/",
+                source_previous_argument_id=None,
+                source_next_argument_id=None,
+                source_domain=ArgsMeSourceDomain.debateorg,
+                source_text=compile("DEBATES OPINIONS FORUMS POLLS Google Search My Deb.{3149}p Version © 2019 Debate\.org\. All rights reserved\. "),
+                source_text_conclusion_start=1630,
+                source_text_conclusion_end=1636,
+                source_text_premise_start=2664,
+                source_text_premise_end=2670,
+                topic="school",
+                acquisition=datetime.fromisoformat("2019-04-18T17:49:41+00:00"),
+                date=None,
+                author=None,
+                author_image_url=None,
+                author_organization=None,
+                author_role=None,
+                mode=ArgsMeMode.discussion,
             ),
             387739: ArgsMeDoc(
                 doc_id="S153cd52f-A118dded8",
-                conclusion="The recent throne speech said that the government would work with Canadians to ensure that our communities continue to be safe.",
+                conclusion=compile("The recent throne speech said that the government .{27}o ensure that our communities continue to be safe\."),
                 premises=[
                     ArgsMePremise(
-                        text="How can Canadians trust the Liberals when they say they will protect children and then avoid positive action on the possession of child pornography? The recent throne speech said that the government would work with Canadians to ensure that our communities continue to be safe. Its focus will be balanced, combining prevention and a community centred approach with action to deal with serious crime. Child pornography is a serious crime and in response on Friday 300,000 Canadians voiced their community-centred approach through a petition against child pornography insisting the government defend the law. In response, the justice minister accuses Reform members of being scaremongers. Obviously the minister does not feel obligated to the community will, and also has no ability to get cabinet approval for action. Children are the most vulnerable members of society and they deserve the fullest protection of the law. Liberal sentiments delivered in regal fashion do not close legal loopholes or defend families. The poor Liberal justice system will only be improved when the system defenders are replaced by the system changers in the opposition.",
+                        text=compile("How can Canadians trust the Liberals when they say.{1049}replaced by the system changers in the opposition\."),
                         stance=ArgsMeStance.CON,
-                        annotations=[]
-                    )
-                ]
+                        annotations=[],
+                    ),
+                ],
+                premises_texts=compile("How can Canadians trust the Liberals when they say.{1049}replaced by the system changers in the opposition\."),
+                aspects=[
+                    ArgsMeAspect(
+                        name="Pornography",
+                        weight=3,
+                        normalized_weight=1,
+                        rank=1,
+                    ),
+                ],
+                aspects_names="Pornography",
+                source_id="S153cd52f",
+                source_title="4129762",
+                source_url=None,
+                source_previous_argument_id=None,
+                source_next_argument_id=None,
+                source_domain=ArgsMeSourceDomain.canadian_parliament,
+                source_text=compile("How can Canadians trust the Liberals when they say.{1050}eplaced by the system changers in the opposition\. "),
+                source_text_conclusion_start=149,
+                source_text_conclusion_end=276,
+                source_text_premise_start=0,
+                source_text_premise_end=1149,
+                topic="Child Pornography",
+                acquisition=datetime.fromisoformat("2019-07-25T09:33:44.811404+00:00"),
+                date=datetime.fromisoformat("1999-10-17T22:00:00+00:00"),
+                author="Paul Forseth",
+                author_image_url="https://www.ourcommons.ca/Parliamentarians/Images/OfficialMPPhotos/38/Forsep.JPG",
+                author_organization="Reform",
+                author_role="Opposition",
+                mode=ArgsMeMode.person,
             ),
         })
         self._test_docs('argsme/2020-04-01/debateorg', count=338620, items={
@@ -152,42 +229,71 @@ class TestArgsMe(DatasetIntegrationTest):
                     ArgsMePremise(
                         text="Done.",
                         stance=ArgsMeStance.PRO,
-                        annotations=[]
-                    )
-                ]
-            ),
-            1: ArgsMeDoc(
-                doc_id="Sb38112c8-A48f87c39",
-                conclusion="school",
-                premises=[
-                    ArgsMePremise(
-                        text="Let's get this over with.",
-                        stance=ArgsMeStance.PRO,
-                        annotations=[]
-                    )
-                ]
-            ),
-            338618: ArgsMeDoc(
-                doc_id="Sca72da7d-Ae83ab999",
-                conclusion="It Should be Legal in the U.S. to Occasionally Hit Someone",
-                premises=[
-                    ArgsMePremise(
-                        text="Thanks to my opponent for instigating this debate, I accept his definitions. ---- It should be pointed out that in some cases it is of course perfectly legal to hit someone. No one is going to be prosecuted for a genuinely playful slap, parents are allowed to discipline minors, you can use reasonable force to defend yourself from attack and some schools still administer occasional corporal punishment under signed consent. [1] There are probably other examples but I will not take the semantic route of invalidating a resolution that calls for the instigation of laws that already exist. I will instead debate my opponent on his opinions. In any case my opponent's definitions make it clear that he advocates delivering blows against just \"some person\" from \"time to time\" which covers just about any instance of provoked or unprovoked hitting. If people were given license to wander around delivering blows to random people who happen to annoy them, the world would be a worse place. I will be proving that in almost all cases a law permitting this kind of hitting is unjust and should not be accepted. ----- 1) Stress relief. Blatantly flawed. Hitting causes more stress than it relieves because being hit is very stressful indeed whereas hitting someone while it may be satisfying does not relieve much. My opponent should provide a source to prove that it can release any stress at all. If you hit someone and then they pull out a knife or a gun, you will find your stress levels increase dramatically. 2) Education. Being hit may teach you not to repeat the exact behaviour that led to being hit but certainly does not teach right from wrong, merely that might is right. Educators agree that self-esteem and confidence are essential to effective learning. Being hit negatively effects these. [2] Hitting someone and not facing the consequences or being compelled to regret it and apologise teaches people that it is OK and even beneficial to behave this way and it certainly isn't. Hitting people will not help you keep friends or hold down a job. 3) Conflict resolution. Fights are less likely to resolve conflicts than exacerbate them, look at the pattern of gang violence where a word out of place can quickly escalate to fists and then even more quickly onto weaponry. People who have been hit may well wish to get some form of revenge. In addition even if it is conceivable that more fights would save on prosecution costs (which I doubt for the reasons above) they can also have a negative economic impact as an injured individual will have to take time off work and will therefore not be contributing to the economy. 4) Exercise. There are far less stressful and more pleasurable forms of exercise even without setting foot in a gym. Sex between consenting adults is a great example. [3] 5) Breeding. By rewarding violence, natural selection will favour the aggressive and the impulsive rather than the enlightened and the thoughtful, not a good end result for species survival. 6) American doctrine. I'm far less informed on this subject than I'm sure my opponent and most readers will be but it is my understanding that an individual's rights are not allowed to infringe on those of another person. A phrase summing this up that I have heard used by many Americans on this site and elsewhere is that \"your right to swing your fist ends where my face begins.\" While I am not suggesting that that is the actual wording of the constitution, I was under the impression that it was a para-phrasing of some of the principles laid out in it. ---- If my opponent really thinks that hitting is acceptable, I can only assume that either he has never taken a good beating himself or he has taken one too many and is suffering from mild brain damage. I'm not a big guy but I'm a grown man and my opponent is a 14 year-old youth, if I lamped him in the head I think he would (rightfully) want me to be punished. ---- That will be all for now. Con. ----- Sources: [1] http://www.corpun.com... [2] http://www.thelearningweb.net... [3] http://www.healthcentral.com...",
-                        stance=ArgsMeStance.CON,
-                        annotations=[]
-                    )
-                ]
+                        annotations=[],
+                    ),
+                ],
+                premises_texts="Done.",
+                aspects=[],
+                aspects_names="",
+                source_id="Sb38112c8",
+                source_title="Debate: school | Debate.org",
+                source_url="https://www.debate.org/debates/school/3/",
+                source_previous_argument_id=None,
+                source_next_argument_id=None,
+                source_domain=ArgsMeSourceDomain.debateorg,
+                source_text=compile("DEBATES OPINIONS FORUMS POLLS Google Search My Deb.{3149}p Version © 2019 Debate\.org\. All rights reserved\. "),
+                source_text_conclusion_start=1630,
+                source_text_conclusion_end=1636,
+                source_text_premise_start=2664,
+                source_text_premise_end=2670,
+                topic="school",
+                acquisition=datetime.fromisoformat("2019-04-18T17:49:41+00:00"),
+                date=None,
+                author=None,
+                author_image_url=None,
+                author_organization=None,
+                author_role=None,
+                mode=ArgsMeMode.discussion,
             ),
             338619: ArgsMeDoc(
                 doc_id="Sca72da7d-Adbd84fd2",
                 conclusion="It Should be Legal in the U.S. to Occasionally Hit Someone",
                 premises=[
                     ArgsMePremise(
-                        text="In this debate, I will argue that occasionally hitting someone should be legal in the U.S. Here are some definitions. Hit: \"b: to deliver (as a blow) by action c: to apply forcefully or suddenly\" http://www.merriam-webster.com...[1] Occasionally: \"on occasion : now and then\" http://www.merriam-webster.com... Someone: \"some person : somebody\" http://www.merriam-webster.com... U.S.: the country known as the United States of America Before I state my arguments, I will clarify that I do not mean hitting with intent to cause permanent physical injury or death. I mean an occasional slap upside the head, or a good punch. Of course, there should be other limitations, such as instances were the action becomes addicting. Argument 1) Stress relief. By occasionally slapping/hitting someone, a great deal of stress is released by the person doing the hitting, especially if they are hitting the person causing the stress. This would decrease general feelings of anger and animosity, which could possibly result in criminal activity. Argument 2) Education. By being hit, a person learns instinctively to avoid the action which caused the hitting. Think of the things that could be learned through such a method of teaching! Argument 3) Conflict resolution. By engaging in fistfights instead of going to the police every time there is conflict, citizens will save many taxpayer dollars. Argument 4) Exercise. We all know that obesity is a problem in America. By legalizing hitting, Americans can resolve their problems while toughening up their fat, weakling bodies. This would result in longer lifespans, greater quality of life, and improved confidence. Argument 5) Breeding. By allowing hitting, certain individuals will pwn others. This will aid natural selection, as the wimpier individuals will not find mates. This will greatly improve the awesomeness of the general American population. Argument 6) American doctrine. As Americans, we believe that all Men have the right to Life, Liberty, and the Pursuit of Happiness. By thwacking the head of the annoying person next to me, I pursue Happiness, as the action gives me great pleasure. The person next to me, who may not initially enjoy the thwacking, will ultimately benefit from it; he will cease to be annoying, which will improve his overall chances of survival. Thus he is granted additional Life. My opponent may begin his argument. Good luck.",
+                        text=compile("In this debate, I will argue that occasionally hit.{2302}fe\. My opponent may begin his argument\. Good luck\."),
                         stance=ArgsMeStance.PRO,
-                        annotations=[]
-                    )
-                ]
+                        annotations=[],
+                    ),
+                ],
+                premises_texts=compile("In this debate, I will argue that occasionally hit.{2302}fe\. My opponent may begin his argument\. Good luck\."),
+                aspects=[
+                    ArgsMeAspect(
+                        name="Obesity",
+                        weight=1,
+                        normalized_weight=1,
+                        rank=1,
+                    ),
+                ],
+                aspects_names="Obesity",
+                source_id="Sca72da7d",
+                source_title="Debate Topic: It Should be Legal in the U.S. to Occasionally Hit Someone | Debate.org",
+                source_url="https://www.debate.org/debates/It-Should-be-Legal-in-the-U.S.-to-Occasionally-Hit-Someone/1/",
+                source_previous_argument_id=None,
+                source_next_argument_id=None,
+                source_domain=ArgsMeSourceDomain.debateorg,
+                source_text=compile("DEBATES OPINIONS FORUMS POLLS Google Search My Deb.{26529}p Version © 2019 Debate\.org\. All rights reserved\. "),
+                source_text_conclusion_start=1677,
+                source_text_conclusion_end=1735,
+                source_text_premise_start=2391,
+                source_text_premise_end=4794,
+                topic="It Should be Legal in the U.S. to Occasionally Hit Someone",
+                acquisition=datetime.fromisoformat("2019-04-18T19:21:03+00:00"),
+                date=None,
+                author=None,
+                author_image_url=None,
+                author_organization=None,
+                author_role=None,
+                mode=ArgsMeMode.discussion,
             ),
         })
         self._test_docs('argsme/2020-04-01/debatepedia', count=21197, items={
@@ -198,42 +304,64 @@ class TestArgsMe(DatasetIntegrationTest):
                     ArgsMePremise(
                         text="Casualties in repelling N. Korean invasion would be higher w/o mines",
                         stance=ArgsMeStance.CON,
-                        annotations=[]
-                    )
-                ]
-            ),
-            1: ArgsMeDoc(
-                doc_id="S96f2396e-Afcc9ac26",
-                conclusion="Mine Ban Treaty (Ottawa Treaty)",
-                premises=[
-                    ArgsMePremise(
-                        text="Mine Ban Treaty fails to distinguish between different kinds of mines.",
-                        stance=ArgsMeStance.CON,
-                        annotations=[]
-                    )
-                ]
-            ),
-            21195: ArgsMeDoc(
-                doc_id="S148bb110-A63b9848c",
-                conclusion="Very few sites globally are appropriate for tidal energy",
-                premises=[
-                    ArgsMePremise(
-                        text="\"Tidal Energy\". Unisun.net.: \"Similar to other ocean energies, tidal energy has several prerequisites that make it only available in a small number of regions. For a tidal power plant to produce electricity effectively (about 85% efficiency), it requires a basin or a gulf that has a mean tidal amplitude (the differences between spring and neap tide) of 7 meters or above. It is also desirable to have semi-diurnal tides where there are two high and low tides everyday. Tides out in the ocean have maximum amplitude of about one meter. As you move closer to shore, this can increase to as high as 12 or more. This can depend on local features such as shelving or funneling meaning the tidal range can vary considerably along any given coastline. This can mean that a lot of places just aren't suitable. When planning the location major consideration has to be given to see whether the tides ar high enough and if there is a suitable place for building the site.\"",
-                        stance=ArgsMeStance.PRO,
-                        annotations=[]
-                    )
-                ]
+                        annotations=[],
+                    ),
+                ],
+                premises_texts="Casualties in repelling N. Korean invasion would be higher w/o mines",
+                aspects=[],
+                aspects_names="",
+                source_id="S96f2396e",
+                source_title="Debate: Mine Ban Treaty (Ottawa Treaty) - Debatepedia",
+                source_url="http://www.debatepedia.org/en/index.php/Debate:_Mine_Ban_Treaty_%28Ottawa_Treaty%29",
+                source_previous_argument_id=None,
+                source_next_argument_id=None,
+                source_domain=ArgsMeSourceDomain.debatepedia,
+                source_text=compile("Welcome to Debatepedia! \| About \| Help \| FAQ \| Med.{33182} Disclaimers Problem with the site\?  Edit Close \. "),
+                source_text_conclusion_start=1063,
+                source_text_conclusion_end=1094,
+                source_text_premise_start=18501,
+                source_text_premise_end=18569,
+                topic="Mine Ban Treaty (Ottawa Treaty)",
+                acquisition=datetime.fromisoformat("2019-04-17T11:47:26+00:00"),
+                date=None,
+                author=None,
+                author_image_url=None,
+                author_organization=None,
+                author_role=None,
+                mode=ArgsMeMode.discussion,
             ),
             21196: ArgsMeDoc(
                 doc_id="S148bb110-A119d66b0",
                 conclusion="Environmental impact of barages is ugly.",
                 premises=[
                     ArgsMePremise(
-                        text="Barages are fairly massive objects, like Dams, that obstruct the natural flow of water and can, subsequently, have harmful environmental impacts. These effects can be very ugly, causing frustration among locals and possibly reduced property values and tourism.",
+                        text=compile("Barages are fairly massive objects, like Dams, tha.{160} and possibly reduced property values and tourism\."),
                         stance=ArgsMeStance.PRO,
-                        annotations=[]
-                    )
-                ]
+                        annotations=[],
+                    ),
+                ],
+                premises_texts=compile("Barages are fairly massive objects, like Dams, tha.{160} and possibly reduced property values and tourism\."),
+                aspects=[],
+                aspects_names="",
+                source_id="S148bb110",
+                source_title="Debate: Tidal energy - Debatepedia",
+                source_url="http://www.debatepedia.org/en/index.php/Debate:_Tidal_energy",
+                source_previous_argument_id=None,
+                source_next_argument_id=None,
+                source_domain=ArgsMeSourceDomain.debatepedia,
+                source_text=compile("Welcome to Debatepedia! \| About \| Help \| FAQ \| Med.{28127} Disclaimers Problem with the site\?  Edit Close \. "),
+                source_text_conclusion_start=22030,
+                source_text_conclusion_end=22070,
+                source_text_premise_start=22070,
+                source_text_premise_end=22331,
+                topic="Tidal energy",
+                acquisition=datetime.fromisoformat("2019-04-17T11:47:38+00:00"),
+                date=None,
+                author=None,
+                author_image_url=None,
+                author_organization=None,
+                author_role=None,
+                mode=ArgsMeMode.discussion,
             ),
         })
         self._test_docs('argsme/2020-04-01/debatewise', count=14353, items={
@@ -242,44 +370,79 @@ class TestArgsMe(DatasetIntegrationTest):
                 conclusion="placebo effect and phenylthiamine",
                 premises=[
                     ArgsMePremise(
-                        text="But are chocolate eaters happy? [[http://news.bbc.co.uk/2/hi/health/8644016.stm]] research suggests that those who eat regular amounts of chocolate are generally depressive/glum/sad. i dont think that chocolate is for us!and i also dont think that that it makes us happy.because if we eat a chocolate it tastes very delicious but we are not satisfied we keep eating more and more and this causes certain diseases like diabeties occurs to small children ,they spoil there teeth ,worms in the intestines ,and i say that those who eat chocolates they are happy but only for time period because everyone will suffer after having the diseases and so much of fat is also not good health !!! as it increases our colestrol in body.",
+                        text=compile("But are chocolate eaters happy\? \[\[http://news\.bbc\..{623} health !!! as it increases our colestrol in body\."),
                         stance=ArgsMeStance.CON,
-                        annotations=[]
-                    )
-                ]
-            ),
-            1: ArgsMeDoc(
-                doc_id="S5920cdef-Ab688a6bc",
-                conclusion="phytonutrients",
-                premises=[
-                    ArgsMePremise(
-                        text="These nutrients are mostly burned off during the making/processing of chocolate.",
-                        stance=ArgsMeStance.CON,
-                        annotations=[]
-                    )
-                ]
-            ),
-            14351: ArgsMeDoc(
-                doc_id="Sc47177f2-A3780249",
-                conclusion="Hitler is evil",
-                premises=[
-                    ArgsMePremise(
-                        text="i personally think that hitler was madder then mad he killed a lot of people he killed hi German shepored that he loved a lot. he got inicent litle disabled babies killed with out thinking twice so he killed a poupilation of pure Germans. so that means he was out of his mind beacause how can you get babies killed. and in the end he was so scared that he commited suicide. so that proves it that he was a coward a murdrer a madman i mean he should have been in a mental ayslum instead of the fuher of Germany",
-                        stance=ArgsMeStance.PRO,
-                        annotations=[]
-                    )
-                ]
+                        annotations=[],
+                    ),
+                ],
+                premises_texts=compile("But are chocolate eaters happy\? \[\[http://news\.bbc\..{623} health !!! as it increases our colestrol in body\."),
+                aspects=[],
+                aspects_names="",
+                source_id="S5920cdef",
+                source_title="Is chocolate good for you? - DebateWise",
+                source_url="https://debatewise.org/debates/1904-is-chocolate-good-for-you/",
+                source_previous_argument_id=None,
+                source_next_argument_id=None,
+                source_domain=ArgsMeSourceDomain.debatewise,
+                source_text=compile("Browse Our Categories Is chocolate good for you\? L.{10743}me \| About Us \| Privacy & Contact Us Top wpDiscuz "),
+                source_text_conclusion_start=751,
+                source_text_conclusion_end=784,
+                source_text_premise_start=1667,
+                source_text_premise_end=2390,
+                topic="Is chocolate good for you?",
+                acquisition=datetime.fromisoformat("2019-04-19T12:46:26+00:00"),
+                date=None,
+                author=None,
+                author_image_url=None,
+                author_organization=None,
+                author_role=None,
+                mode=ArgsMeMode.discussion,
             ),
             14352: ArgsMeDoc(
                 doc_id="Sc47177f2-A730d8f9e",
                 conclusion="NO",
                 premises=[
                     ArgsMePremise(
-                        text="\u200e:/ Adolf Hitler was not evil he wasn't a murderer he didn't kill the jews directly he ordered people to kill the jews. you might be thinking \" he ordered the soldiers to kill them so he has to be evil.\" well your wrong in my point of view its like this,if the U.S President Or Whoever Is In Power Told You To Jump Off A Bridge Would You Do It?",
+                        text=compile("‎:/ Adolf Hitler was not evil he wasn't a murderer.{244}wer Told You To Jump Off A Bridge Would You Do It\?"),
                         stance=ArgsMeStance.PRO,
-                        annotations=[]
-                    )
-                ]
+                        annotations=[],
+                    ),
+                ],
+                premises_texts=compile("‎:/ Adolf Hitler was not evil he wasn't a murderer.{244}wer Told You To Jump Off A Bridge Would You Do It\?"),
+                aspects=[
+                    ArgsMeAspect(
+                        name="Jews",
+                        weight=2,
+                        normalized_weight=0.6666666666666666,
+                        rank=1,
+                    ),
+                    ArgsMeAspect(
+                        name="Adolf Hitler",
+                        weight=1,
+                        normalized_weight=0.3333333333333333,
+                        rank=2,
+                    ),
+                ],
+                aspects_names="Jews Adolf Hitler",
+                source_id="Sc47177f2",
+                source_title="Adolf Hitler Does Not Deserve His Reputation as Evil - DebateWise",
+                source_url="https://debatewise.org/debates/357-adolf-hitler-does-not-deserve-his-reputation-as-evil/",
+                source_previous_argument_id=None,
+                source_next_argument_id=None,
+                source_domain=ArgsMeSourceDomain.debatewise,
+                source_text=compile("Browse Our Categories Adolf Hitler Does Not Deserv.{54510} Us \| Privacy & Contact Us Top wpDiscuz 113shares "),
+                source_text_conclusion_start=43380,
+                source_text_conclusion_end=43382,
+                source_text_premise_start=43383,
+                source_text_premise_end=43727,
+                topic="Adolf Hitler Does Not Deserve His Reputation as Evil",
+                acquisition=datetime.fromisoformat("2019-04-19T12:44:52+00:00"),
+                date=None,
+                author=None,
+                author_image_url=None,
+                author_organization=None,
+                author_role=None,
+                mode=ArgsMeMode.discussion,
             ),
         })
         self._test_docs('argsme/2020-04-01/idebate', count=13522, items={
@@ -290,88 +453,165 @@ class TestArgsMe(DatasetIntegrationTest):
                     ArgsMePremise(
                         text="His removal provides stability and security not only for Iraq but for the Middle East as a region",
                         stance=ArgsMeStance.PRO,
-                        annotations=[]
-                    )
-                ]
-            ),
-            1: ArgsMeDoc(
-                doc_id="Sf9294c83-A9a4e056e",
-                conclusion="Saddam Hussein is gone and Iraq is now functioning as one of very few democracies in the Middle East",
-                premises=[
-                    ArgsMePremise(
-                        text="It's important to be clear that this debate is looking at the results of the Iraq war and, by any definition Iraq is in a much more stable and secure position than it was in 2003 when American, British and other international troops arrived in the country. Whatever one thinks of the initial justifications for the war there is no doubt that the country, the region and the world are better and safer places without Saddam Hussein[i]. It is easy to criticize the allies but it is worth bearing in mind that the alternative was leaving in power a man who had committed genocide was a vicious and brutal dictator under whose regime extra-judicial execution and detention, mass-murder and torture were commonplace[ii]. [i] Richard Miniter. “Was the Iraq War Worth It?”. Hudson New York. 2 September 2010. [ii] Interview with Donald Rumsfeld. Inside Politics. NPR. 14 February 2011.",
-                        stance=ArgsMeStance.PRO,
-                        annotations=[]
-                    )
-                ]
-            ),
-            13520: ArgsMeDoc(
-                doc_id="Sd6cf79d9-A82ab9dc3",
-                conclusion="Socialism leads to a more humane equal society",
-                premises=[
-                    ArgsMePremise(
-                        text="The reasons behind the poverty gap are not purely because of a capitalist expansion; a clear example may be seen at the development of the African region between the 1960. Free market economics also provides the solution to such inequality; labor will gravitate towards companies which provide the best working conditions and wages. For example, while most automobile companies offered two dollars per day as wages, Henry ford offered five, guaranteeing him the best of the best by way of labor. The important point is that the employers do not enslave the workers, the workers are more than free to try to find better employment, be it in better pay, better conditions, easier work, better benefits or more satisfaction.",
-                        stance=ArgsMeStance.CON,
-                        annotations=[]
-                    )
-                ]
+                        annotations=[],
+                    ),
+                ],
+                premises_texts="His removal provides stability and security not only for Iraq but for the Middle East as a region",
+                aspects=[],
+                aspects_names="",
+                source_id="Sf9294c83",
+                source_title="This House Believes that the War in Iraq was Worth the Cost | idebate.org",
+                source_url="https://idebate.org/debatabase/international-middle-east-politics-terrorism-warpeace/house-believes-war-iraq-was-worth",
+                source_previous_argument_id=None,
+                source_next_argument_id=None,
+                source_domain=ArgsMeSourceDomain.idebate,
+                source_text=compile("idebate\.org Educational and informative news and r.{17520}in with\.\.\. Login with Facebook Login with Twitter "),
+                source_text_conclusion_start=196,
+                source_text_conclusion_end=230,
+                source_text_premise_start=8137,
+                source_text_premise_end=8234,
+                topic="the War in Iraq was Worth the Cost",
+                acquisition=datetime.fromisoformat("2019-04-19T12:40:25+00:00"),
+                date=None,
+                author=None,
+                author_image_url=None,
+                author_organization=None,
+                author_role=None,
+                mode=ArgsMeMode.discussion,
             ),
             13521: ArgsMeDoc(
                 doc_id="Sd6cf79d9-Af8d9e187",
                 conclusion="Socialism is a more secure system than the free market in Capitalism",
                 premises=[
                     ArgsMePremise(
-                        text="In order to avoid economic crisis there is a need to return to a separation of commercial banking from investment banking which was e.g. implemented as legislation in the U.S.A. under the 1933 Glass-Steagall Act (scrapped under President Clinton in the 1990s). It is dangerous to allow banks to get into a position where they can be shut down by pursuing exciting, but high risk investment banking activities such as real estate speculations. The rationale for this separation is that it was a commercial banking crisis which posed the systemic risk, investment banks should be left alone from state interference and left to the influence of the market. \"This leaves a much more limited, and practicable, but still absolutely essential, role for bank supervision and regulation: namely, to ensure that the core commercial banking system is thoroughly sound and adequately capitalised at all times. The crisis can thus be resolved through a separation of the banks since the commercial banking won't be affected when investment banks go bust, the whole system will not be dragged down if only a few investment banks misbehave since commercial banks are the backbone of the economy. Financial crisis doesn't have to be something \"inherent\" in the capitalist system due to overproduction but can be accommodated through some regulations1. 1 Lawson, N. (2009). Capitalism needs a revived Glass-Steagall. Financial Times. Retrieved June 14, 2011 1.",
+                        text=compile("In order to avoid economic crisis there is a need .{1343}agall\. Financial Times\. Retrieved June 14, 2011 1\."),
                         stance=ArgsMeStance.CON,
-                        annotations=[]
-                    )
-                ]
+                        annotations=[],
+                    ),
+                ],
+                premises_texts=compile("In order to avoid economic crisis there is a need .{1343}agall\. Financial Times\. Retrieved June 14, 2011 1\."),
+                aspects=[
+                    ArgsMeAspect(
+                        name="Capitalism",
+                        weight=2,
+                        normalized_weight=0.6666666666666666,
+                        rank=1,
+                    ),
+                    ArgsMeAspect(
+                        name="Socialism",
+                        weight=1,
+                        normalized_weight=0.3333333333333333,
+                        rank=2,
+                    ),
+                ],
+                aspects_names="Capitalism Socialism",
+                source_id="Sd6cf79d9",
+                source_title="This House believes that capitalism is better than socialism | idebate.org",
+                source_url="https://idebate.org/debatabase/economy-economy-general-philosophy-political-philosophy/house-believes-capitalism-better",
+                source_previous_argument_id=None,
+                source_next_argument_id=None,
+                source_domain=ArgsMeSourceDomain.idebate,
+                source_text=compile("idebate\.org Educational and informative news and r.{29663}in with\.\.\. Login with Facebook Login with Twitter "),
+                source_text_conclusion_start=19722,
+                source_text_conclusion_end=19790,
+                source_text_premise_start=21487,
+                source_text_premise_end=22930,
+                topic="capitalism is better than socialism",
+                acquisition=datetime.fromisoformat("2019-04-19T12:39:56+00:00"),
+                date=None,
+                author=None,
+                author_image_url=None,
+                author_organization=None,
+                author_role=None,
+                mode=ArgsMeMode.discussion,
             ),
         })
         self._test_docs('argsme/2020-04-01/parliamentary', count=48, items={
             0: ArgsMeDoc(
                 doc_id="S1f6b58eb-A5c530110",
-                conclusion="I want them to know that their braids, their dreads, their super curly Afro puffs, their weaves, their hijabs, and their head scarves, and all other variety of hairstyles, belong in schools, in the workplace, in the boardroom, and yes, even here on Parliament Hill.",
+                conclusion=compile("I want them to know that their braids, their dread.{165} boardroom, and yes, even here on Parliament Hill\."),
                 premises=[
                     ArgsMePremise(
-                        text="This week I have my hair in braids, much like I have had for most of my childhood. However, it has come to my attention that there are young girls here in Canada and other parts of the world who are removed from school, or shamed because of their hairstyle. Body shaming of any woman in any form from the top of her head to the soles of her feet is wrong, irrespective of her hairstyle, the size of her thighs, the size of her hips, the size of her baby bump, the size of her breasts, or the size of her lips. What makes is different makes us unique and beautiful. I will continue to rock these braids for three reasons. Number one, because I am sure everyone will agree, they look pretty dope; number two, in solidarity with women who have been shamed based on their appearance; and number three, and most importantly, in solidarity with young girls and women who look like me and those who do not. I want them to know that their braids, their dreads, their super curly Afro puffs, their weaves, their hijabs, and their head scarves, and all other variety of hairstyles, belong in schools, in the workplace, in the boardroom, and yes, even here on Parliament Hill.",
+                        text=compile("I want them to know that their braids, their dread.{165} boardroom, and yes, even here on Parliament Hill\."),
                         stance=ArgsMeStance.PRO,
-                        annotations=[]
-                    )
-                ]
-            ),
-            1: ArgsMeDoc(
-                doc_id="S1a9db4fc-Acc4206f5",
-                conclusion="On November 10, UN Women elected its first executive board.",
-                premises=[
-                    ArgsMePremise(
-                        text="On November 10, UN Women elected its first executive board. This new agency “will work...to improve the status of women and girls”, said United Nations Deputy Secretary-General Asha-Rose Migiro. This entity, charged with ensuring that the UN's commitments to establish gender equality within its institutions are kept, is a competent authority among member states for bringing about this equality. It is troubling to see that Saudi Arabia has a seat on this executive board. The customs and traditions of that country infringe on women's rights daily. It is a country where Nathalie Morin, a Quebecker, is stuck and being held prisoner, along with her children. If Saudi Arabia wants to demonstrate its desire for equality and justice between men and women, then its authorities have to take the first concrete step and let Nathalie Morin and her children return to Quebec.",
-                        stance=ArgsMeStance.PRO,
-                        annotations=[]
-                    )
-                ]
-            ),
-            46: ArgsMeDoc(
-                doc_id="S18eb2e1a-Afe2ebde7",
-                conclusion="Single female seniors are particularly challenged.",
-                premises=[
-                    ArgsMePremise(
-                        text="Canada's economy may be doing well, but across the country there are millions of Canadians who live in poverty. This is especially true for women and children, as has been reported across the country today. Single female seniors are particularly challenged. One report provides the example of a single female senior who, having worked all her life to raise her three children, has had to give up her car, buy second-hand clothes and live on combined benefits of $16,000 per year. The United Nations agency for children, UNICEF, reports that in Canada “our children are suffering from unacceptable rates of poverty”. The levels of poverty in this country, especially for women and children, are totally unacceptable. The Leader of the Opposition has recently outlined real and meaningful plans to deal with the issue of poverty in Canada, but from the government we hear nothing. That is an absolute shame. Canadians deserve better.",
-                        stance=ArgsMeStance.CON,
-                        annotations=[]
-                    )
-                ]
+                        annotations=[],
+                    ),
+                ],
+                premises_texts=compile("I want them to know that their braids, their dread.{165} boardroom, and yes, even here on Parliament Hill\."),
+                aspects=[
+                    ArgsMeAspect(
+                        name="Women",
+                        weight=2,
+                        normalized_weight=0.6666666666666666,
+                        rank=1,
+                    ),
+                    ArgsMeAspect(
+                        name="Woman",
+                        weight=1,
+                        normalized_weight=0.3333333333333333,
+                        rank=2,
+                    ),
+                ],
+                aspects_names="Women Woman",
+                source_id="S1f6b58eb",
+                source_title="4718632",
+                source_url=None,
+                source_previous_argument_id=None,
+                source_next_argument_id=None,
+                source_domain=ArgsMeSourceDomain.canadian_parliament,
+                source_text=compile("This week I have my hair in braids, much like I ha.{1066}boardroom, and yes, even here on Parliament Hill\. "),
+                source_text_conclusion_start=900,
+                source_text_conclusion_end=1165,
+                source_text_premise_start=0,
+                source_text_premise_end=1165,
+                topic="Body Shaming",
+                acquisition=datetime.fromisoformat("2019-07-25T09:33:44.814585+00:00"),
+                date=datetime.fromisoformat("2017-09-19T22:00:00+00:00"),
+                author="Celina Caesar-Chavannes",
+                author_image_url="https://www.ourcommons.ca/Parliamentarians/Images/OfficialMPPhotos/42/CaesarChavannesCelina_Lib.jpg",
+                author_organization="Liberal",
+                author_role="Government",
+                mode=ArgsMeMode.person,
             ),
             47: ArgsMeDoc(
                 doc_id="S153cd52f-A118dded8",
-                conclusion="The recent throne speech said that the government would work with Canadians to ensure that our communities continue to be safe.",
+                conclusion=compile("The recent throne speech said that the government .{27}o ensure that our communities continue to be safe\."),
                 premises=[
                     ArgsMePremise(
-                        text="How can Canadians trust the Liberals when they say they will protect children and then avoid positive action on the possession of child pornography? The recent throne speech said that the government would work with Canadians to ensure that our communities continue to be safe. Its focus will be balanced, combining prevention and a community centred approach with action to deal with serious crime. Child pornography is a serious crime and in response on Friday 300,000 Canadians voiced their community-centred approach through a petition against child pornography insisting the government defend the law. In response, the justice minister accuses Reform members of being scaremongers. Obviously the minister does not feel obligated to the community will, and also has no ability to get cabinet approval for action. Children are the most vulnerable members of society and they deserve the fullest protection of the law. Liberal sentiments delivered in regal fashion do not close legal loopholes or defend families. The poor Liberal justice system will only be improved when the system defenders are replaced by the system changers in the opposition.",
+                        text=compile("How can Canadians trust the Liberals when they say.{1049}replaced by the system changers in the opposition\."),
                         stance=ArgsMeStance.CON,
-                        annotations=[]
-                    )
-                ]
+                        annotations=[],
+                    ),
+                ],
+                premises_texts=compile("How can Canadians trust the Liberals when they say.{1049}replaced by the system changers in the opposition\."),
+                aspects=[
+                    ArgsMeAspect(
+                        name="Pornography",
+                        weight=3,
+                        normalized_weight=1,
+                        rank=1,
+                    ),
+                ],
+                aspects_names="Pornography",
+                source_id="S153cd52f",
+                source_title="4129762",
+                source_url=None,
+                source_previous_argument_id=None,
+                source_next_argument_id=None,
+                source_domain=ArgsMeSourceDomain.canadian_parliament,
+                source_text=compile("How can Canadians trust the Liberals when they say.{1050}eplaced by the system changers in the opposition\. "),
+                source_text_conclusion_start=149,
+                source_text_conclusion_end=276,
+                source_text_premise_start=0,
+                source_text_premise_end=1149,
+                topic="Child Pornography",
+                acquisition=datetime.fromisoformat("2019-07-25T09:33:44.811404+00:00"),
+                date=datetime.fromisoformat("1999-10-17T22:00:00+00:00"),
+                author="Paul Forseth",
+                author_image_url="https://www.ourcommons.ca/Parliamentarians/Images/OfficialMPPhotos/38/Forsep.JPG",
+                author_organization="Reform",
+                author_role="Opposition",
+                mode=ArgsMeMode.person,
             ),
         })
 

--- a/test/integration/argsme.py
+++ b/test/integration/argsme.py
@@ -1,26 +1,379 @@
 from unittest import main
 
+from ir_datasets.formats import ArgsMeDoc, ArgsMePremise, ArgsMeStance
 from test.integration.base import DatasetIntegrationTest
 
 
 class TestArgsMe(DatasetIntegrationTest):
     def test_docs(self):
         self._test_docs('argsme/1.0', count=387692, items={
-        })
+            0: ArgsMeDoc(
+                doc_id="c67482ba-2019-04-18T13:32:05Z-00000-000",
+                conclusion="Contraceptive Forms for High School Students",
+                premises=[
+                    ArgsMePremise(
+                        text="My opponent forfeited every round. None of my arguments were answered. I don’t like the idea of winning by default, but here we are.Tule: it’s good for students to get involved and address big issues like teen pregnancy. You need to be able to answer arguments like mine and not simply prepare for an abstinence-only type of response. You should also be aware that, in the U.S., condoms may be sold to minors in ANY state. A retailer who says it is illegal to sell you them is, frankly, wrong.",
+                        stance=ArgsMeStance.CON,
+                        annotations=[]
+                    )
+                ]
+            ),
+            1: ArgsMeDoc(
+                doc_id="c67482ba-2019-04-18T13:32:05Z-00001-000",
+                conclusion="Contraceptive Forms for High School Students",
+                premises=[
+                    ArgsMePremise(
+                        text="How do you propose the school will fund your program? Condoms cost money and checking an \"opt out\" list before handing them out takes time away from staff members whenever they could be doing their actual jobs. Your \"opt out\" option is only be a token to parental authority and would be easily subverted. If everyone in school except a handful of students had access to free condoms, do you not think those students would simply ask their friends to provide them with condoms?",
+                        stance=ArgsMeStance.CON,
+                        annotations=[]
+                    )
+                ]
+            ),
+            387690: ArgsMeDoc(
+                doc_id="671509c8-2019-04-17T11:47:34Z-00022-000",
+                conclusion="Charter schools",
+                premises=[
+                    ArgsMePremise(
+                        text="Charter schools are damaging private schools",
+                        stance=ArgsMeStance.CON,
+                        annotations=[]
+                    )
+                ]
+            ),
+            387691: ArgsMeDoc(
+                doc_id="671509c8-2019-04-17T11:47:34Z-00007-000",
+                conclusion="Charter schools",
+                premises=[
+                    ArgsMePremise(
+                        text="Charter schools are exploited most by affable students",
+                        stance=ArgsMeStance.CON,
+                        annotations=[]
+                    )
+                ]
+            ),
+        }, test_iter_split=False)
         self._test_docs('argsme/1.0-cleaned', count=382545, items={
-        })
+            0: ArgsMeDoc(
+                doc_id="c67482ba-2019-04-18T13:32:05Z-00000-000",
+                conclusion="Contraceptive Forms for High School Students",
+                premises=[
+                    ArgsMePremise(
+                        text="My opponent forfeited every round. None of my arguments were answered. I don’t like the idea of winning by default, but here we are.Tule: it’s good for students to get involved and address big issues like teen pregnancy. You need to be able to answer arguments like mine and not simply prepare for an abstinence-only type of response. You should also be aware that, in the U.S., condoms may be sold to minors in ANY state. A retailer who says it is illegal to sell you them is, frankly, wrong.",
+                        stance=ArgsMeStance.CON,
+                        annotations=[]
+                    )
+                ]
+            ),
+            1: ArgsMeDoc(
+                doc_id="c67482ba-2019-04-18T13:32:05Z-00001-000",
+                conclusion="Contraceptive Forms for High School Students",
+                premises=[
+                    ArgsMePremise(
+                        text="How do you propose the school will fund your program? Condoms cost money and checking an \"opt out\" list before handing them out takes time away from staff members whenever they could be doing their actual jobs. Your \"opt out\" option is only be a token to parental authority and would be easily subverted. If everyone in school except a handful of students had access to free condoms, do you not think those students would simply ask their friends to provide them with condoms?",
+                        stance=ArgsMeStance.CON,
+                        annotations=[]
+                    )
+                ]
+            ),
+            382543: ArgsMeDoc(
+                doc_id="671509c8-2019-04-17T11:47:34Z-00022-000",
+                conclusion="Charter schools",
+                premises=[
+                    ArgsMePremise(
+                        text="Charter schools are damaging private schools",
+                        stance=ArgsMeStance.CON,
+                        annotations=[]
+                    )
+                ]
+            ),
+            382544: ArgsMeDoc(
+                doc_id="671509c8-2019-04-17T11:47:34Z-00007-000",
+                conclusion="Charter schools",
+                premises=[
+                    ArgsMePremise(
+                        text="Charter schools are exploited most by affable students",
+                        stance=ArgsMeStance.CON,
+                        annotations=[]
+                    )
+                ]
+            ),
+        }, test_iter_split=False)
         self._test_docs('argsme/2020-04-01', count=387740, items={
-        })
+            0: ArgsMeDoc(
+                doc_id="Sb38112c8-A443a9828",
+                conclusion="school",
+                premises=[
+                    ArgsMePremise(
+                        text="Done.",
+                        stance=ArgsMeStance.PRO,
+                        annotations=[]
+                    )
+                ]
+            ),
+            1: ArgsMeDoc(
+                doc_id="Sb38112c8-A48f87c39",
+                conclusion="school",
+                premises=[
+                    ArgsMePremise(
+                        text="Let's get this over with.",
+                        stance=ArgsMeStance.PRO,
+                        annotations=[]
+                    )
+                ]
+            ),
+            387738: ArgsMeDoc(
+                doc_id="S18eb2e1a-Afe2ebde7",
+                conclusion="Single female seniors are particularly challenged.",
+                premises=[
+                    ArgsMePremise(
+                        text="Canada's economy may be doing well, but across the country there are millions of Canadians who live in poverty. This is especially true for women and children, as has been reported across the country today. Single female seniors are particularly challenged. One report provides the example of a single female senior who, having worked all her life to raise her three children, has had to give up her car, buy second-hand clothes and live on combined benefits of $16,000 per year. The United Nations agency for children, UNICEF, reports that in Canada “our children are suffering from unacceptable rates of poverty”. The levels of poverty in this country, especially for women and children, are totally unacceptable. The Leader of the Opposition has recently outlined real and meaningful plans to deal with the issue of poverty in Canada, but from the government we hear nothing. That is an absolute shame. Canadians deserve better.",
+                        stance=ArgsMeStance.CON,
+                        annotations=[]
+                    )
+                ]
+            ),
+            387739: ArgsMeDoc(
+                doc_id="S153cd52f-A118dded8",
+                conclusion="The recent throne speech said that the government would work with Canadians to ensure that our communities continue to be safe.",
+                premises=[
+                    ArgsMePremise(
+                        text="How can Canadians trust the Liberals when they say they will protect children and then avoid positive action on the possession of child pornography? The recent throne speech said that the government would work with Canadians to ensure that our communities continue to be safe. Its focus will be balanced, combining prevention and a community centred approach with action to deal with serious crime. Child pornography is a serious crime and in response on Friday 300,000 Canadians voiced their community-centred approach through a petition against child pornography insisting the government defend the law. In response, the justice minister accuses Reform members of being scaremongers. Obviously the minister does not feel obligated to the community will, and also has no ability to get cabinet approval for action. Children are the most vulnerable members of society and they deserve the fullest protection of the law. Liberal sentiments delivered in regal fashion do not close legal loopholes or defend families. The poor Liberal justice system will only be improved when the system defenders are replaced by the system changers in the opposition.",
+                        stance=ArgsMeStance.CON,
+                        annotations=[]
+                    )
+                ]
+            ),
+        }, test_iter_split=False)
         self._test_docs('argsme/2020-04-01/debateorg', count=338620, items={
-        })
+            0: ArgsMeDoc(
+                doc_id="Sb38112c8-A443a9828",
+                conclusion="school",
+                premises=[
+                    ArgsMePremise(
+                        text="Done.",
+                        stance=ArgsMeStance.PRO,
+                        annotations=[]
+                    )
+                ]
+            ),
+            1: ArgsMeDoc(
+                doc_id="Sb38112c8-A48f87c39",
+                conclusion="school",
+                premises=[
+                    ArgsMePremise(
+                        text="Let's get this over with.",
+                        stance=ArgsMeStance.PRO,
+                        annotations=[]
+                    )
+                ]
+            ),
+            338618: ArgsMeDoc(
+                doc_id="Sca72da7d-Ae83ab999",
+                conclusion="It Should be Legal in the U.S. to Occasionally Hit Someone",
+                premises=[
+                    ArgsMePremise(
+                        text="Thanks to my opponent for instigating this debate, I accept his definitions. ---- It should be pointed out that in some cases it is of course perfectly legal to hit someone. No one is going to be prosecuted for a genuinely playful slap, parents are allowed to discipline minors, you can use reasonable force to defend yourself from attack and some schools still administer occasional corporal punishment under signed consent. [1] There are probably other examples but I will not take the semantic route of invalidating a resolution that calls for the instigation of laws that already exist. I will instead debate my opponent on his opinions. In any case my opponent's definitions make it clear that he advocates delivering blows against just \"some person\" from \"time to time\" which covers just about any instance of provoked or unprovoked hitting. If people were given license to wander around delivering blows to random people who happen to annoy them, the world would be a worse place. I will be proving that in almost all cases a law permitting this kind of hitting is unjust and should not be accepted. ----- 1) Stress relief. Blatantly flawed. Hitting causes more stress than it relieves because being hit is very stressful indeed whereas hitting someone while it may be satisfying does not relieve much. My opponent should provide a source to prove that it can release any stress at all. If you hit someone and then they pull out a knife or a gun, you will find your stress levels increase dramatically. 2) Education. Being hit may teach you not to repeat the exact behaviour that led to being hit but certainly does not teach right from wrong, merely that might is right. Educators agree that self-esteem and confidence are essential to effective learning. Being hit negatively effects these. [2] Hitting someone and not facing the consequences or being compelled to regret it and apologise teaches people that it is OK and even beneficial to behave this way and it certainly isn't. Hitting people will not help you keep friends or hold down a job. 3) Conflict resolution. Fights are less likely to resolve conflicts than exacerbate them, look at the pattern of gang violence where a word out of place can quickly escalate to fists and then even more quickly onto weaponry. People who have been hit may well wish to get some form of revenge. In addition even if it is conceivable that more fights would save on prosecution costs (which I doubt for the reasons above) they can also have a negative economic impact as an injured individual will have to take time off work and will therefore not be contributing to the economy. 4) Exercise. There are far less stressful and more pleasurable forms of exercise even without setting foot in a gym. Sex between consenting adults is a great example. [3] 5) Breeding. By rewarding violence, natural selection will favour the aggressive and the impulsive rather than the enlightened and the thoughtful, not a good end result for species survival. 6) American doctrine. I'm far less informed on this subject than I'm sure my opponent and most readers will be but it is my understanding that an individual's rights are not allowed to infringe on those of another person. A phrase summing this up that I have heard used by many Americans on this site and elsewhere is that \"your right to swing your fist ends where my face begins.\" While I am not suggesting that that is the actual wording of the constitution, I was under the impression that it was a para-phrasing of some of the principles laid out in it. ---- If my opponent really thinks that hitting is acceptable, I can only assume that either he has never taken a good beating himself or he has taken one too many and is suffering from mild brain damage. I'm not a big guy but I'm a grown man and my opponent is a 14 year-old youth, if I lamped him in the head I think he would (rightfully) want me to be punished. ---- That will be all for now. Con. ----- Sources: [1] http://www.corpun.com... [2] http://www.thelearningweb.net... [3] http://www.healthcentral.com...",
+                        stance=ArgsMeStance.CON,
+                        annotations=[]
+                    )
+                ]
+            ),
+            338619: ArgsMeDoc(
+                doc_id="Sca72da7d-Adbd84fd2",
+                conclusion="It Should be Legal in the U.S. to Occasionally Hit Someone",
+                premises=[
+                    ArgsMePremise(
+                        text="In this debate, I will argue that occasionally hitting someone should be legal in the U.S. Here are some definitions. Hit: \"b: to deliver (as a blow) by action c: to apply forcefully or suddenly\" http://www.merriam-webster.com...[1] Occasionally: \"on occasion : now and then\" http://www.merriam-webster.com... Someone: \"some person : somebody\" http://www.merriam-webster.com... U.S.: the country known as the United States of America Before I state my arguments, I will clarify that I do not mean hitting with intent to cause permanent physical injury or death. I mean an occasional slap upside the head, or a good punch. Of course, there should be other limitations, such as instances were the action becomes addicting. Argument 1) Stress relief. By occasionally slapping/hitting someone, a great deal of stress is released by the person doing the hitting, especially if they are hitting the person causing the stress. This would decrease general feelings of anger and animosity, which could possibly result in criminal activity. Argument 2) Education. By being hit, a person learns instinctively to avoid the action which caused the hitting. Think of the things that could be learned through such a method of teaching! Argument 3) Conflict resolution. By engaging in fistfights instead of going to the police every time there is conflict, citizens will save many taxpayer dollars. Argument 4) Exercise. We all know that obesity is a problem in America. By legalizing hitting, Americans can resolve their problems while toughening up their fat, weakling bodies. This would result in longer lifespans, greater quality of life, and improved confidence. Argument 5) Breeding. By allowing hitting, certain individuals will pwn others. This will aid natural selection, as the wimpier individuals will not find mates. This will greatly improve the awesomeness of the general American population. Argument 6) American doctrine. As Americans, we believe that all Men have the right to Life, Liberty, and the Pursuit of Happiness. By thwacking the head of the annoying person next to me, I pursue Happiness, as the action gives me great pleasure. The person next to me, who may not initially enjoy the thwacking, will ultimately benefit from it; he will cease to be annoying, which will improve his overall chances of survival. Thus he is granted additional Life. My opponent may begin his argument. Good luck.",
+                        stance=ArgsMeStance.PRO,
+                        annotations=[]
+                    )
+                ]
+            ),
+        }, test_iter_split=False)
         self._test_docs('argsme/2020-04-01/debatepedia', count=21197, items={
-        })
+            0: ArgsMeDoc(
+                doc_id="S96f2396e-Aaf079b43",
+                conclusion="Mine Ban Treaty (Ottawa Treaty)",
+                premises=[
+                    ArgsMePremise(
+                        text="Casualties in repelling N. Korean invasion would be higher w/o mines",
+                        stance=ArgsMeStance.CON,
+                        annotations=[]
+                    )
+                ]
+            ),
+            1: ArgsMeDoc(
+                doc_id="S96f2396e-Afcc9ac26",
+                conclusion="Mine Ban Treaty (Ottawa Treaty)",
+                premises=[
+                    ArgsMePremise(
+                        text="Mine Ban Treaty fails to distinguish between different kinds of mines.",
+                        stance=ArgsMeStance.CON,
+                        annotations=[]
+                    )
+                ]
+            ),
+            21195: ArgsMeDoc(
+                doc_id="S148bb110-A63b9848c",
+                conclusion="Very few sites globally are appropriate for tidal energy",
+                premises=[
+                    ArgsMePremise(
+                        text="\"Tidal Energy\". Unisun.net.: \"Similar to other ocean energies, tidal energy has several prerequisites that make it only available in a small number of regions. For a tidal power plant to produce electricity effectively (about 85% efficiency), it requires a basin or a gulf that has a mean tidal amplitude (the differences between spring and neap tide) of 7 meters or above. It is also desirable to have semi-diurnal tides where there are two high and low tides everyday. Tides out in the ocean have maximum amplitude of about one meter. As you move closer to shore, this can increase to as high as 12 or more. This can depend on local features such as shelving or funneling meaning the tidal range can vary considerably along any given coastline. This can mean that a lot of places just aren't suitable. When planning the location major consideration has to be given to see whether the tides ar high enough and if there is a suitable place for building the site.\"",
+                        stance=ArgsMeStance.PRO,
+                        annotations=[]
+                    )
+                ]
+            ),
+            21196: ArgsMeDoc(
+                doc_id="S148bb110-A119d66b0",
+                conclusion="Environmental impact of barages is ugly.",
+                premises=[
+                    ArgsMePremise(
+                        text="Barages are fairly massive objects, like Dams, that obstruct the natural flow of water and can, subsequently, have harmful environmental impacts. These effects can be very ugly, causing frustration among locals and possibly reduced property values and tourism.",
+                        stance=ArgsMeStance.PRO,
+                        annotations=[]
+                    )
+                ]
+            ),
+        }, test_iter_split=False)
         self._test_docs('argsme/2020-04-01/debatewise', count=14353, items={
-        })
+            0: ArgsMeDoc(
+                doc_id="S5920cdef-A982becb7",
+                conclusion="placebo effect and phenylthiamine",
+                premises=[
+                    ArgsMePremise(
+                        text="But are chocolate eaters happy? [[http://news.bbc.co.uk/2/hi/health/8644016.stm]] research suggests that those who eat regular amounts of chocolate are generally depressive/glum/sad. i dont think that chocolate is for us!and i also dont think that that it makes us happy.because if we eat a chocolate it tastes very delicious but we are not satisfied we keep eating more and more and this causes certain diseases like diabeties occurs to small children ,they spoil there teeth ,worms in the intestines ,and i say that those who eat chocolates they are happy but only for time period because everyone will suffer after having the diseases and so much of fat is also not good health !!! as it increases our colestrol in body.",
+                        stance=ArgsMeStance.CON,
+                        annotations=[]
+                    )
+                ]
+            ),
+            1: ArgsMeDoc(
+                doc_id="S5920cdef-Ab688a6bc",
+                conclusion="phytonutrients",
+                premises=[
+                    ArgsMePremise(
+                        text="These nutrients are mostly burned off during the making/processing of chocolate.",
+                        stance=ArgsMeStance.CON,
+                        annotations=[]
+                    )
+                ]
+            ),
+            14351: ArgsMeDoc(
+                doc_id="Sc47177f2-A3780249",
+                conclusion="Hitler is evil",
+                premises=[
+                    ArgsMePremise(
+                        text="i personally think that hitler was madder then mad he killed a lot of people he killed hi German shepored that he loved a lot. he got inicent litle disabled babies killed with out thinking twice so he killed a poupilation of pure Germans. so that means he was out of his mind beacause how can you get babies killed. and in the end he was so scared that he commited suicide. so that proves it that he was a coward a murdrer a madman i mean he should have been in a mental ayslum instead of the fuher of Germany",
+                        stance=ArgsMeStance.PRO,
+                        annotations=[]
+                    )
+                ]
+            ),
+            14352: ArgsMeDoc(
+                doc_id="Sc47177f2-A730d8f9e",
+                conclusion="NO",
+                premises=[
+                    ArgsMePremise(
+                        text="\u200e:/ Adolf Hitler was not evil he wasn't a murderer he didn't kill the jews directly he ordered people to kill the jews. you might be thinking \" he ordered the soldiers to kill them so he has to be evil.\" well your wrong in my point of view its like this,if the U.S President Or Whoever Is In Power Told You To Jump Off A Bridge Would You Do It?",
+                        stance=ArgsMeStance.PRO,
+                        annotations=[]
+                    )
+                ]
+            ),
+        }, test_iter_split=False)
         self._test_docs('argsme/2020-04-01/idebate', count=13522, items={
-        })
+            0: ArgsMeDoc(
+                doc_id="Sf9294c83-Af186e851",
+                conclusion="the War in Iraq was Worth the Cost",
+                premises=[
+                    ArgsMePremise(
+                        text="His removal provides stability and security not only for Iraq but for the Middle East as a region",
+                        stance=ArgsMeStance.PRO,
+                        annotations=[]
+                    )
+                ]
+            ),
+            1: ArgsMeDoc(
+                doc_id="Sf9294c83-A9a4e056e",
+                conclusion="Saddam Hussein is gone and Iraq is now functioning as one of very few democracies in the Middle East",
+                premises=[
+                    ArgsMePremise(
+                        text="It's important to be clear that this debate is looking at the results of the Iraq war and, by any definition Iraq is in a much more stable and secure position than it was in 2003 when American, British and other international troops arrived in the country. Whatever one thinks of the initial justifications for the war there is no doubt that the country, the region and the world are better and safer places without Saddam Hussein[i]. It is easy to criticize the allies but it is worth bearing in mind that the alternative was leaving in power a man who had committed genocide was a vicious and brutal dictator under whose regime extra-judicial execution and detention, mass-murder and torture were commonplace[ii]. [i] Richard Miniter. “Was the Iraq War Worth It?”. Hudson New York. 2 September 2010. [ii] Interview with Donald Rumsfeld. Inside Politics. NPR. 14 February 2011.",
+                        stance=ArgsMeStance.PRO,
+                        annotations=[]
+                    )
+                ]
+            ),
+            13520: ArgsMeDoc(
+                doc_id="Sd6cf79d9-A82ab9dc3",
+                conclusion="Socialism leads to a more humane equal society",
+                premises=[
+                    ArgsMePremise(
+                        text="The reasons behind the poverty gap are not purely because of a capitalist expansion; a clear example may be seen at the development of the African region between the 1960. Free market economics also provides the solution to such inequality; labor will gravitate towards companies which provide the best working conditions and wages. For example, while most automobile companies offered two dollars per day as wages, Henry ford offered five, guaranteeing him the best of the best by way of labor. The important point is that the employers do not enslave the workers, the workers are more than free to try to find better employment, be it in better pay, better conditions, easier work, better benefits or more satisfaction.",
+                        stance=ArgsMeStance.CON,
+                        annotations=[]
+                    )
+                ]
+            ),
+            13521: ArgsMeDoc(
+                doc_id="Sd6cf79d9-Af8d9e187",
+                conclusion="Socialism is a more secure system than the free market in Capitalism",
+                premises=[
+                    ArgsMePremise(
+                        text="In order to avoid economic crisis there is a need to return to a separation of commercial banking from investment banking which was e.g. implemented as legislation in the U.S.A. under the 1933 Glass-Steagall Act (scrapped under President Clinton in the 1990s). It is dangerous to allow banks to get into a position where they can be shut down by pursuing exciting, but high risk investment banking activities such as real estate speculations. The rationale for this separation is that it was a commercial banking crisis which posed the systemic risk, investment banks should be left alone from state interference and left to the influence of the market. \"This leaves a much more limited, and practicable, but still absolutely essential, role for bank supervision and regulation: namely, to ensure that the core commercial banking system is thoroughly sound and adequately capitalised at all times. The crisis can thus be resolved through a separation of the banks since the commercial banking won't be affected when investment banks go bust, the whole system will not be dragged down if only a few investment banks misbehave since commercial banks are the backbone of the economy. Financial crisis doesn't have to be something \"inherent\" in the capitalist system due to overproduction but can be accommodated through some regulations1. 1 Lawson, N. (2009). Capitalism needs a revived Glass-Steagall. Financial Times. Retrieved June 14, 2011 1.",
+                        stance=ArgsMeStance.CON,
+                        annotations=[]
+                    )
+                ]
+            ),
+        }, test_iter_split=False)
         self._test_docs('argsme/2020-04-01/parliamentary', count=48, items={
-        })
+            0: ArgsMeDoc(
+                doc_id="S1f6b58eb-A5c530110",
+                conclusion="I want them to know that their braids, their dreads, their super curly Afro puffs, their weaves, their hijabs, and their head scarves, and all other variety of hairstyles, belong in schools, in the workplace, in the boardroom, and yes, even here on Parliament Hill.",
+                premises=[
+                    ArgsMePremise(
+                        text="This week I have my hair in braids, much like I have had for most of my childhood. However, it has come to my attention that there are young girls here in Canada and other parts of the world who are removed from school, or shamed because of their hairstyle. Body shaming of any woman in any form from the top of her head to the soles of her feet is wrong, irrespective of her hairstyle, the size of her thighs, the size of her hips, the size of her baby bump, the size of her breasts, or the size of her lips. What makes is different makes us unique and beautiful. I will continue to rock these braids for three reasons. Number one, because I am sure everyone will agree, they look pretty dope; number two, in solidarity with women who have been shamed based on their appearance; and number three, and most importantly, in solidarity with young girls and women who look like me and those who do not. I want them to know that their braids, their dreads, their super curly Afro puffs, their weaves, their hijabs, and their head scarves, and all other variety of hairstyles, belong in schools, in the workplace, in the boardroom, and yes, even here on Parliament Hill.",
+                        stance=ArgsMeStance.PRO,
+                        annotations=[]
+                    )
+                ]
+            ),
+            1: ArgsMeDoc(
+                doc_id="S1a9db4fc-Acc4206f5",
+                conclusion="On November 10, UN Women elected its first executive board.",
+                premises=[
+                    ArgsMePremise(
+                        text="On November 10, UN Women elected its first executive board. This new agency “will work...to improve the status of women and girls”, said United Nations Deputy Secretary-General Asha-Rose Migiro. This entity, charged with ensuring that the UN's commitments to establish gender equality within its institutions are kept, is a competent authority among member states for bringing about this equality. It is troubling to see that Saudi Arabia has a seat on this executive board. The customs and traditions of that country infringe on women's rights daily. It is a country where Nathalie Morin, a Quebecker, is stuck and being held prisoner, along with her children. If Saudi Arabia wants to demonstrate its desire for equality and justice between men and women, then its authorities have to take the first concrete step and let Nathalie Morin and her children return to Quebec.",
+                        stance=ArgsMeStance.PRO,
+                        annotations=[]
+                    )
+                ]
+            ),
+            46: ArgsMeDoc(
+                doc_id="S18eb2e1a-Afe2ebde7",
+                conclusion="Single female seniors are particularly challenged.",
+                premises=[
+                    ArgsMePremise(
+                        text="Canada's economy may be doing well, but across the country there are millions of Canadians who live in poverty. This is especially true for women and children, as has been reported across the country today. Single female seniors are particularly challenged. One report provides the example of a single female senior who, having worked all her life to raise her three children, has had to give up her car, buy second-hand clothes and live on combined benefits of $16,000 per year. The United Nations agency for children, UNICEF, reports that in Canada “our children are suffering from unacceptable rates of poverty”. The levels of poverty in this country, especially for women and children, are totally unacceptable. The Leader of the Opposition has recently outlined real and meaningful plans to deal with the issue of poverty in Canada, but from the government we hear nothing. That is an absolute shame. Canadians deserve better.",
+                        stance=ArgsMeStance.CON,
+                        annotations=[]
+                    )
+                ]
+            ),
+            47: ArgsMeDoc(
+                doc_id="S153cd52f-A118dded8",
+                conclusion="The recent throne speech said that the government would work with Canadians to ensure that our communities continue to be safe.",
+                premises=[
+                    ArgsMePremise(
+                        text="How can Canadians trust the Liberals when they say they will protect children and then avoid positive action on the possession of child pornography? The recent throne speech said that the government would work with Canadians to ensure that our communities continue to be safe. Its focus will be balanced, combining prevention and a community centred approach with action to deal with serious crime. Child pornography is a serious crime and in response on Friday 300,000 Canadians voiced their community-centred approach through a petition against child pornography insisting the government defend the law. In response, the justice minister accuses Reform members of being scaremongers. Obviously the minister does not feel obligated to the community will, and also has no ability to get cabinet approval for action. Children are the most vulnerable members of society and they deserve the fullest protection of the law. Liberal sentiments delivered in regal fashion do not close legal loopholes or defend families. The poor Liberal justice system will only be improved when the system defenders are replaced by the system changers in the opposition.",
+                        stance=ArgsMeStance.CON,
+                        annotations=[]
+                    )
+                ]
+            ),
+        }, test_iter_split=False)
 
 
 if __name__ == '__main__':

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -260,6 +260,8 @@ self._test_qlogs({repr(dataset_name)}, count={count}, items={self._repr_namedtup
                 self.assertRegex(v_b, v_a)
             elif isinstance(v_a, tuple) and isinstance(v_b, tuple):
                 self._assert_namedtuple(v_a, v_b)
+            elif isinstance(v_a, list) and isinstance(v_b, list):
+                self._assert_namedtuple(v_a, v_b)
             else:
                 self.assertEqual(v_a, v_b)
 


### PR DESCRIPTION
Fixes #127.

I'm not sure how to implement the iterator slicing. Therefore, I disabled the check in the integration test (`test_iter_split=False`).
I'd appreciate any help.

I also switched to another ID naming scheme for args.me as the corpus has 3 different versions on Zenodo.
Now the following IDs:
- `argsme/1.0`
- `argsme/1.0-cleaned`
- `argsme/2020-04-01`
- `argsme/2020-04-01/debateorg`
- `argsme/2020-04-01/debatepedia`
- `argsme/2020-04-01/debatewise`
- `argsme/2020-04-01/idebate`
- `argsme/2020-04-01/parliamentary`