### PR TITLE
Update tsv.py

### DIFF
--- a/ir_datasets/formats/tsv.py
+++ b/ir_datasets/formats/tsv.py
@@ -26,6 +26,7 @@ class FileLineIter:
                 self.stream = io.TextIOWrapper(self.ctxt.enter_context(self.dlc[self.stream_idx].stream()))
             else:
                 self.stream = io.TextIOWrapper(self.ctxt.enter_context(self.dlc.stream()))
+        line = ''
         while self.pos < self.start:
             line = self.stream.readline()
             if line != '\n':


### PR DESCRIPTION
The following code doesn't run correctly it the docstore is not already cached in pklz4 folder:

```
import ir_datasets
import more_itertools

dataset = ir_datasets.load('msmarco-passage')

for batch in more_itertools.chunked(dataset.docs_iter(), 8196*4):
    print(len(batch))
```

With this single line, it can, without raising exceptions.