### PR TITLE
Add msmarco v2.1 trec rag

### DIFF
--- a/ir_datasets/datasets/__init__.py
+++ b/ir_datasets/datasets/__init__.py
@@ -30,6 +30,7 @@ from . import mr_tydi
 from . import msmarco_document
 from . import msmarco_document_v2
 from . import msmarco_document_v2_1
+from . import msmarco_document_v2_1_segmented
 from . import msmarco_passage
 from . import msmarco_passage_v2
 from . import msmarco_qna

--- a/ir_datasets/datasets/__init__.py
+++ b/ir_datasets/datasets/__init__.py
@@ -29,6 +29,7 @@ from . import mmarco
 from . import mr_tydi
 from . import msmarco_document
 from . import msmarco_document_v2
+from . import msmarco_document_v2_1
 from . import msmarco_passage
 from . import msmarco_passage_v2
 from . import msmarco_qna

--- a/ir_datasets/datasets/msmarco_document_v2_1.py
+++ b/ir_datasets/datasets/msmarco_document_v2_1.py
@@ -75,16 +75,11 @@ def _init():
     base_path = ir_datasets.util.home_path()/NAME
     documentation = YamlDocumentation(f'docs/{NAME}.yaml')
     dlc = DownloadConfig.context(NAME, base_path, dua=DUA)
-    subsets = {}
-    
     collection = MsMarcoV21Docs(dlc['docs'])
-    for docs in collection.docs_iter():
-        print(docs)
-        break
+    subsets = {}
 
-    ds = collection.docs_store()
-    document = ds.get("msmarco_v2.1_doc_12_0")
-    print(document)
+    ir_datasets.registry.register(NAME, Dataset(collection, documentation('_')))
+    
+    return collection, subsets
 
-if __name__ == "__main__":
-    _init()
+collection, subsets = _init()

--- a/ir_datasets/datasets/msmarco_document_v2_1.py
+++ b/ir_datasets/datasets/msmarco_document_v2_1.py
@@ -19,6 +19,10 @@ _logger = ir_datasets.log.easy()
 NAME = 'msmarco-document-v2.1'
 
 
+class MsMarcoV21Document(MsMarcoV2Document):
+    # Identical to V2 Document
+    pass
+
 class MsMarcoV21DocStore(ir_datasets.indices.Docstore):    
     def __init__(self, doc_cls, dlc, base_path):
         super().__init__(doc_cls)
@@ -46,7 +50,7 @@ class MsMarcoV21DocStore(ir_datasets.indices.Docstore):
             document = json.loads(json_string)
 
             assert document["docid"] == doc_id
-            return MsMarcoV2Document(
+            return MsMarcoV21Document(
                 document['docid'],
                 document['url'],
                 document['title'],
@@ -69,7 +73,6 @@ class MsMarcoV21Docs(MsMarcoV2Docs):
         ir_datasets.util.home_path() / NAME / "docs")
         ds.build()
         return ds
-
 
 def _init():
     base_path = ir_datasets.util.home_path()/NAME

--- a/ir_datasets/datasets/msmarco_document_v2_1.py
+++ b/ir_datasets/datasets/msmarco_document_v2_1.py
@@ -1,0 +1,90 @@
+import contextlib
+import gzip
+import io
+from pathlib import Path
+import json
+from typing import NamedTuple, Tuple, List
+import tarfile
+import ir_datasets
+from ir_datasets.indices import PickleLz4FullStore
+from ir_datasets.util import Cache, DownloadConfig, GzipExtract, Lazy, Migrator, TarExtractAll, TarExtract
+from ir_datasets.datasets.base import Dataset, YamlDocumentation, FilteredQueries, FilteredScoredDocs, FilteredQrels
+from ir_datasets.formats import TsvQueries, TrecQrels, TrecScoredDocs, BaseDocs
+from ir_datasets.datasets.msmarco_passage import DUA, DL_HARD_QIDS_BYFOLD, DL_HARD_QIDS
+from ir_datasets.datasets.msmarco_document import TREC_DL_QRELS_DEFS
+from ir_datasets.datasets.msmarco_document_v2 import MsMarcoV2Docs, MsMarcoV2Document
+
+_logger = ir_datasets.log.easy()
+
+NAME = 'msmarco-document-v2.1'
+
+
+class MsMarcoV21DocStore(ir_datasets.indices.Docstore):    
+    def __init__(self, doc_cls, dlc, base_path):
+        super().__init__(doc_cls)
+        self.dlc = dlc
+        self.cache = None
+        self.base_path = base_path
+
+    def built(self):
+        return False
+
+    def build(self):
+        if self.cache:
+            return
+        self.cache = Cache(TarExtractAll(self.dlc, "msmarco_v2.1_doc"), self.base_path)
+
+    def get(self, doc_id, field=None):
+        (string1, string2, string3, bundlenum, position) = doc_id.split("_")
+        assert string1 == "msmarco" and string2 == "v2.1" and string3 == "doc"
+
+        with open(
+            f"{self.cache.path()}/msmarco_v2.1_doc_{bundlenum}.json", "rt", encoding="utf8"
+        ) as in_fh:
+            in_fh.seek(int(position))
+            json_string = in_fh.readline()
+            document = json.loads(json_string)
+
+            assert document["docid"] == doc_id
+            return MsMarcoV2Document(
+                document['docid'],
+                document['url'],
+                document['title'],
+                document['headings'],
+                document['body'])
+        
+        # raise KeyError(f'doc_id={doc_id} not found')
+
+
+class MsMarcoV21Docs(MsMarcoV2Docs):
+    _fields = ["doc_id"]
+    def __init__(self, dlc):
+        super().__init__(dlc)
+
+    def __iter__():
+        pass
+
+    def docs_store(self, field='doc_id'):
+        ds = MsMarcoV21DocStore(self, self._dlc, 
+        ir_datasets.util.home_path() / NAME / "docs")
+        ds.build()
+        return ds
+
+
+def _init():
+    base_path = ir_datasets.util.home_path()/NAME
+    documentation = YamlDocumentation(f'docs/{NAME}.yaml')
+    dlc = DownloadConfig.context(NAME, base_path, dua=DUA)
+    subsets = {}
+    
+    collection = MsMarcoV21Docs(dlc['docs'])
+    for docs in collection.docs_iter():
+        print(docs)
+        break
+
+    ds = collection.docs_store()
+    document = ds.get("msmarco_v2.1_doc_12_0")
+    print(document)
+
+if __name__ == "__main__":
+    _init()

--- a/ir_datasets/datasets/msmarco_document_v2_1_segmented.py
+++ b/ir_datasets/datasets/msmarco_document_v2_1_segmented.py
@@ -1,0 +1,156 @@
+import contextlib
+import gzip
+import io
+from pathlib import Path
+import json
+from typing import NamedTuple, Tuple, List
+import tarfile
+import ir_datasets
+from ir_datasets.util import Cache, DownloadConfig, GzipExtract, Lazy, Migrator, TarExtractAll, TarExtract
+from ir_datasets.datasets.base import Dataset, YamlDocumentation, FilteredQueries, FilteredScoredDocs, FilteredQrels
+from ir_datasets.formats import TsvQueries, TrecQrels, TrecScoredDocs, BaseDocs
+from ir_datasets.datasets.msmarco_passage import DUA, DL_HARD_QIDS_BYFOLD, DL_HARD_QIDS
+import os.path
+import shutil
+
+_logger = ir_datasets.log.easy()
+
+NAME = 'msmarco-document-v2.1'
+
+
+class MsMarcoV21SegmentedDocument(NamedTuple):
+    doc_id: str
+    url: str
+    title: str
+    headings: str
+    segment: str
+    start_char: int
+    end_char: int
+    def default_text(self):
+        """
+        title + headings + segment
+        This is consistent with the MsMarcoV21Document that returns the full text alternative of this: title + headings + body
+        Please note that Anserini additionaly returns the url. I.e., anserini returns url + title + headings + segment
+        E.g., https://github.com/castorini/anserini/blob/b8ce19f56bc4e85056ef703322f76646804ec640/src/main/java/io/anserini/collection/MsMarcoV2DocCollection.java#L169
+        """
+        return f'{self.title} {self.headings} {self.segment}'
+
+
+def ensure_file_is_extracted(file_name):
+    if os.path.isfile(file_name):
+        return
+    import tempfile
+    tmp_file = Path(tempfile.mkdtemp()) / file_name.split('/')[-1]
+    
+    with gzip.open(file_name + '.gz', 'rb') as f_in:
+        with open(tmp_file, 'wb') as f_out:
+            shutil.copyfileobj(f_in, f_out)
+    shutil.move(tmp_file, file_name)
+
+
+class MsMarcoV21SegmentedDocStore(ir_datasets.indices.Docstore):    
+    def __init__(self, doc_cls, dlc, base_path):
+        super().__init__(doc_cls)
+        self.dlc = dlc
+        self.cache = None
+        self.base_path = base_path
+
+    def built(self):
+        return False
+
+    def build(self):
+        if self.cache:
+            return
+        self.cache = Cache(TarExtractAll(self.dlc, "msmarco_v2.1_doc_segmented"), self.base_path)
+
+        for i in range(0, 59):
+            ensure_file_is_extracted(f"{self.cache.path()}/msmarco_v2.1_doc_segmented_{i:02d}.json")
+
+
+    def get(self, doc_id, field=None):
+        (string1, string2, string3, bundlenum, doc_position, position) = doc_id.split("_")
+        assert string1 == "msmarco" and string2 == "v2.1" and string3 == "doc"
+
+        with open(
+            f"{self.cache.path()}/msmarco_v2.1_doc_segmented_{bundlenum}.json", "rt", encoding="utf8"
+        ) as in_fh:
+            in_fh.seek(int(position))
+            json_string = in_fh.readline()
+            document = json.loads(json_string)
+
+            assert document["docid"] == doc_id
+            return MsMarcoV21SegmentedDocument(
+                document['docid'],
+                document['url'],
+                document['title'],
+                document['headings'],
+                document['segment'],
+                document['start_char'],
+                document['end_char']
+            )
+        
+
+class MsMarcoV21Docs(BaseDocs):
+    _fields = ["doc_id"]
+    def __init__(self, dlc):
+        super().__init__()
+        self._dlc = dlc
+
+    @ir_datasets.util.use_docstore
+    def docs_iter(self):
+        with self._dlc.stream() as stream, \
+             tarfile.open(fileobj=stream, mode='r|') as tarf:
+            for record in tarf:
+                if not record.name.endswith('.gz'):
+                    continue
+                file = tarf.extractfile(record)
+                with gzip.open(file) as file:
+                    for line in file:
+                        data = json.loads(line)
+                        yield MsMarcoV21SegmentedDocument(
+                            data['docid'],
+                            data['url'],
+                            data['title'],
+                            data['headings'],
+                            data['segment'],
+                            data['start_char'],
+                            data['end_char'],
+                        )
+
+    def docs_cls(self):
+        return MsMarcoV21SegmentedDocument
+
+    def __iter__():
+        pass
+
+    def docs_store(self, field='doc_id'):
+        ds = MsMarcoV21SegmentedDocStore(self, self._dlc, 
+        ir_datasets.util.home_path() / NAME / "docs-segmented")
+        ds.build()
+        return ds
+
+    def docs_count(self):
+        if self.docs_store().built():
+            return self.docs_store().count()
+
+    def docs_namespace(self):
+        return NAME
+
+    def docs_lang(self):
+        return 'en'
+
+
+def _init():
+    base_path = ir_datasets.util.home_path()/NAME
+    documentation = YamlDocumentation(f'docs/{NAME}.yaml')
+    dlc = DownloadConfig.context(NAME, base_path, dua=DUA)
+    collection = MsMarcoV21Docs(dlc['docs-segmented'])
+    subsets = {}
+
+    ir_datasets.registry.register(NAME + '/segmented', Dataset(collection, documentation('_')))
+    collection
+    print(collection.docs_iter().__next__())
+    
+    return collection, subsets
+
+collection, subsets = _init()

--- a/ir_datasets/docs/msmarco-document-v2.1.yaml
+++ b/ir_datasets/docs/msmarco-document-v2.1.yaml
@@ -1,0 +1,14 @@
+_:
+  pretty_name: 'MSMARCO (document, version 2.1)'
+  desc: '
+  <p>
+Version 2.1 of the MS MARCO document ranking dataset used in TREC RAG 2024.
+</p>
+<ul>
+  <li>Version 1 of dataset: <a class="ds-ref">msmarco-document</a></li>
+  <li>Documents: Text extracted from web pages</li>
+  <li>Queries: Natural language questions (from query log)</li>
+  <li> TODO: add paper describing the dataset.</li>
+</ul>'
+  bibtex_ids: []
+

--- a/ir_datasets/etc/downloads.json
+++ b/ir_datasets/etc/downloads.json
@@ -4714,6 +4714,23 @@
     }
   },
   
+  "msmarco-document-v2.1": {
+    "docs": {
+      "url": "https://msmarco.z22.web.core.windows.net/msmarcoranking/msmarco_v2.1_doc.tar",
+      "size_hint": 30844989440,
+      "expected_md5_foo": "a5950665d6448d3dbaf7135645f1e074",
+      "cache_path": "msmarco_v2.1_doc.tar",
+      "download_args": {"headers": {"X-Ms-Version": "2024-07-10"}}
+    },
+    "docs-segmented": {
+      "url": "https://msmarco.z22.web.core.windows.net/msmarcoranking/msmarco_v2.1_doc_segmented.tar",
+      "size_hint": 26918768640,
+      "expected_md5_foo": "3799e7611efffd8daeb257e9ccca4d60",
+      "cache_path": "msmarco_v2.1_doc_segmented.tar",
+      "download_args": {"headers": {"X-Ms-Version": "2024-07-10"}}
+    }
+  },
+
   "msmarco-passage": {
     "collectionandqueries": {
       "url": "https://msmarco.z22.web.core.windows.net/msmarcoranking/collectionandqueries.tar.gz",

--- a/test/integration/msmarco_document_v2_1.py
+++ b/test/integration/msmarco_document_v2_1.py
@@ -1,0 +1,66 @@
+import re
+import unittest
+import ir_datasets
+from ir_datasets.datasets.msmarco_document_v2_1 import MsMarcoV2Document
+from ir_datasets.formats import TrecQrel, GenericQuery
+from .base import DatasetIntegrationTest
+
+
+_logger = ir_datasets.log.easy()
+
+
+class TestMSMarcoV21Docs(DatasetIntegrationTest):
+    def test_ms_marco_docs_iter_full(self):
+        self._test_docs('msmarco-document-v2.1', count=5371, items={
+            0: MsMarcoV2Document(
+                doc_id='msmarco_v2.1_doc_12_0',
+                title='Who Is Ringo Starr\'s Wife Barbara Bach and How Many Children Do They Have?',
+                url='https://answersafrica.com/ringo-starrs-wife-children.html',
+                headings=re.compile('.*Wife Barbara Bach.*'),
+                body=re.compile('^Who Is Ringo Starr\'s Wife Barbara Bach.*')
+            ),
+            9: MsMarcoV2Document(
+                doc_id='msmarco_v2.1_doc_12_70974',
+                title='List of Robin Williams Movies and TV Shows From Best To Worst',
+                url='https://answersafrica.com/robin-williams-movies-tv-shows.html',
+                headings=re.compile('List of Robin Williams Movies and TV Shows.*'),
+                body=re.compile('List of Robin Williams Movies and TV Shows From Best To Worst\nList of Robin Williams Movies and TV Shows From Best To Worst*')
+            ),
+            5370: MsMarcoV2Document(
+                doc_id='msmarco_v2.1_doc_12_48692010',
+                title='Warriors of Waterdeep 2.11.13 (Mod) latest',
+                url='https://apkdry.com/warriors-of-waterdeep-2-3-24-mod/',
+                headings=re.compile('^Warriors of Waterdeep 2.11.13 \(Mod\)\\nWarriors of Waterdeep 2.11.13 \(Mod\)\\nFeatures and Screenshots Warriors of Waterdeep Game for Android.*'),
+                body=re.compile('Warriors of Waterdeep 2.11.13 \(Mod\) latest\\nWarriors of Waterdeep 2.11.13 \(Mod\)\\nby Apkdry 3 weeks ago Games.*')
+            ),
+        })
+
+    def test_fast_ms_marco_docs_store(self):
+        docs_store = ir_datasets.load('msmarco-document-v2.1').docs_store()
+
+        doc = docs_store.get('msmarco_v2.1_doc_12_0')
+        self.assertEqual('msmarco_v2.1_doc_12_0', doc.doc_id)
+
+        doc = docs_store.get('msmarco_v2.1_doc_12_48692010')
+        self.assertEqual('msmarco_v2.1_doc_12_48692010', doc.doc_id)
+
+    def test_fast_docs_store_on_non_existing_documents(self):
+        docs_store = ir_datasets.load('msmarco-document-v2.1').docs_store()
+
+        with self.assertRaises(Exception) as context:
+            doc = docs_store.get('msmarco_v2.1_doc_12_111')
+
+        self.assertTrue('Expecting value: line 1 column 1' in str(context.exception))
+
+    def test_fast_ms_marco_docs_iter(self):
+        # faster alternative to above
+        docs_iter = ir_datasets.load('msmarco-document-v2.1').docs_iter()
+        first_doc = docs_iter.__next__()
+        second_doc = docs_iter.__next__()
+
+        self.assertEqual('msmarco_v2.1_doc_12_0', first_doc.doc_id)
+        self.assertEqual('msmarco_v2.1_doc_12_5689', second_doc.doc_id)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/integration/msmarco_document_v2_1.py
+++ b/test/integration/msmarco_document_v2_1.py
@@ -1,7 +1,7 @@
 import re
 import unittest
 import ir_datasets
-from ir_datasets.datasets.msmarco_document_v2_1 import MsMarcoV2Document
+from ir_datasets.datasets.msmarco_document_v2_1 import MsMarcoV21Document
 from ir_datasets.formats import TrecQrel, GenericQuery
 from .base import DatasetIntegrationTest
 
@@ -12,21 +12,21 @@ _logger = ir_datasets.log.easy()
 class TestMSMarcoV21Docs(DatasetIntegrationTest):
     def test_ms_marco_docs_iter_full(self):
         self._test_docs('msmarco-document-v2.1', count=5371, items={
-            0: MsMarcoV2Document(
+            0: MsMarcoV21Document(
                 doc_id='msmarco_v2.1_doc_12_0',
                 title='Who Is Ringo Starr\'s Wife Barbara Bach and How Many Children Do They Have?',
                 url='https://answersafrica.com/ringo-starrs-wife-children.html',
                 headings=re.compile('.*Wife Barbara Bach.*'),
                 body=re.compile('^Who Is Ringo Starr\'s Wife Barbara Bach.*')
             ),
-            9: MsMarcoV2Document(
+            9: MsMarcoV21Document(
                 doc_id='msmarco_v2.1_doc_12_70974',
                 title='List of Robin Williams Movies and TV Shows From Best To Worst',
                 url='https://answersafrica.com/robin-williams-movies-tv-shows.html',
                 headings=re.compile('List of Robin Williams Movies and TV Shows.*'),
                 body=re.compile('List of Robin Williams Movies and TV Shows From Best To Worst\nList of Robin Williams Movies and TV Shows From Best To Worst*')
             ),
-            5370: MsMarcoV2Document(
+            5370: MsMarcoV21Document(
                 doc_id='msmarco_v2.1_doc_12_48692010',
                 title='Warriors of Waterdeep 2.11.13 (Mod) latest',
                 url='https://apkdry.com/warriors-of-waterdeep-2-3-24-mod/',

--- a/test/integration/msmarco_document_v2_1_segmented.py
+++ b/test/integration/msmarco_document_v2_1_segmented.py
@@ -1,0 +1,72 @@
+import re
+import unittest
+import ir_datasets
+from ir_datasets.datasets.msmarco_document_v2_1_segmented import MsMarcoV21SegmentedDocument
+from ir_datasets.formats import TrecQrel, GenericQuery
+from .base import DatasetIntegrationTest
+
+
+_logger = ir_datasets.log.easy()
+
+
+class TestMSMarcoV21DocsSegmented(DatasetIntegrationTest):
+    def test_ms_marco_docs_iter_full(self):
+        self._test_docs('msmarco-document-v2.1/segmented', count=5371, items={
+            0: MsMarcoV21SegmentedDocument(
+                doc_id='msmarco_v2.1_doc_42_0#0_0',
+                title='How to Use Flip Tool in GIMP',
+                url='https://www.guidingtech.com/use-flip-tool-gimp/',
+                headings=re.compile('^How to Use Flip Tool in\\nGIMP\\n\\nHow to Use Flip Tool in GIMP.*'),
+                segment=re.compile('^How to Use Flip Tool in GIMP\\nHow to Use Flip Tool in GIMP\\nMehvish\\n06 Sep 2019.*'),
+                start_char=0,
+                end_char=800
+            ),
+           19: MsMarcoV21SegmentedDocument(
+                doc_id='msmarco_v2.1_doc_42_6080#2_22424',
+                title='How to Setup and Use FTP Server on Android',
+                url='https://www.guidingtech.com/use-ftp-server-file-transfer-android/',
+                headings=re.compile('How to Set\\u00adup and Use\\nFTP\nServ\\u00ader on Android\.*'),
+                segment=re.compile('^Also Read: Best Alternatives to Google Apps\\nIn this post.*'),
+                start_char=1032,
+                end_char=1959
+            ),
+            5370: MsMarcoV21SegmentedDocument(
+                doc_id='msmarco_v2.1_doc_42_3400697#6_9024928',
+                title='Can Guinea Pigs Eat Leaves? - Guinea Pig Tube',
+                url='https://www.guineapigtube.com/can-guinea-pigs-eat-leaves/',
+                headings=re.compile('^Can Guinea Pigs Eat Leaves\?\\nCan Guinea Pigs Eat Leaves\?.*'),
+                segment=re.compile('^They protect the body from free radical damage. The free radicals cause many health problems and also cause premature aging in guinea pigs.*'),
+                start_char=2954,
+                end_char=3767,
+            ),
+        })
+
+    def test_fast_ms_marco_docs_store(self):
+        docs_store = ir_datasets.load('msmarco-document-v2.1/segmented').docs_store()
+
+        doc = docs_store.get('msmarco_v2.1_doc_02_968#0_1561')
+        self.assertEqual('msmarco_v2.1_doc_02_968#0_1561', doc.doc_id)
+
+        doc = docs_store.get('msmarco_v2.1_doc_03_0#3_5523')
+        self.assertEqual('msmarco_v2.1_doc_03_0#3_5523', doc.doc_id)
+
+    def test_fast_docs_store_on_non_existing_documents(self):
+        docs_store = ir_datasets.load('msmarco-document-v2.1/segmented').docs_store()
+
+        with self.assertRaises(Exception) as context:
+            doc = docs_store.get('msmarco_v2.1_doc_02_968#0_156')
+
+        self.assertTrue('Expecting value: line 1 column 1' in str(context.exception))
+
+    def test_fast_ms_marco_docs_iter(self):
+        # faster alternative to above
+        docs_iter = ir_datasets.load('msmarco-document-v2.1/segmented').docs_iter()
+        first_doc = docs_iter.__next__()
+        second_doc = docs_iter.__next__()
+
+        self.assertEqual('msmarco_v2.1_doc_42_0#0_0', first_doc.doc_id)
+        self.assertEqual('msmarco_v2.1_doc_42_0#1_1311', second_doc.doc_id)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Dear all,

with a focus on the current TREC Rag task, this is an initial implementation for accessing documents via the corpus_iter and the document store for the document and the segmented document datasets of MS MARCO v2.1.

This is not completely finished (i.e., mainly documentation todos in the [corresponding tickets are open](https://github.com/allenai/ir_datasets/issues/267)), but as the deadline is soon, this might be useful for others even when the documentation is not yet completed.